### PR TITLE
Rename display name to OpenSalon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<img src="readme-banner.png" alt="Open Salon preview" width="100%" />
+<img src="readme-banner.png" alt="OpenSalon preview" width="100%" />
 
-# Open Salon: The Open-Source Salonist & Fresha Alternative
+# OpenSalon: The Open-Source Salonist & Fresha Alternative
 
 [![Deploy with Clawnify](https://app.clawnify.com/deploy-button.svg)](https://app.clawnify.com/deploy?repo=clawnify/open-salon)
 
@@ -10,13 +10,13 @@ Built with **Preact + Tailwind CSS v4 + shadcn/ui + Hono + SQLite**. Ships with 
 
 ## What Is It?
 
-Open Salon is a production-ready appointment scheduling platform designed for the OpenClaw community. Think of it as an open-source alternative to **Salonist**, **Fresha**, **Square Appointments**, **Vagaro**, or **Booksy** — a complete booking and staff management system you can self-host, customize, and embed in any SaaS product.
+OpenSalon is a production-ready appointment scheduling platform designed for the OpenClaw community. Think of it as an open-source alternative to **Salonist**, **Fresha**, **Square Appointments**, **Vagaro**, or **Booksy** — a complete booking and staff management system you can self-host, customize, and embed in any SaaS product.
 
 Unlike Salonist or Fresha, this runs entirely on your own infrastructure. No per-user fees, no booking commissions, no vendor lock-in. Manage your entire appointment-based operation from scheduling to inventory.
 
 ## Built for Every Appointment-Based Business
 
-Open Salon is **vertical-agnostic** — configure services, pricing, and staff for any industry:
+OpenSalon is **vertical-agnostic** — configure services, pricing, and staff for any industry:
 
 | Industry | Example Services |
 |----------|-----------------|

--- a/clawnify.json
+++ b/clawnify.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://app.clawnify.com/schema/v1/clawnify.json",
   "version": 1,
-  "name": "Salon & Booking Manager",
+  "name": "OpenSalon",
   "description": "Appointment scheduling and business management for salons, spas, barbershops, tattoo studios, nail salons, pet groomers, personal trainers, yoga studios, med spas, physiotherapy clinics, tutoring centers, and any appointment-based business. Like Salonist, Fresha, Square Appointments, or Vagaro.",
   "icon": "icon.svg",
   "tags": ["booking", "appointments", "salon", "scheduling"],

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Salon & Booking Manager",
+  "name": "OpenSalon",
   "description": "Appointment scheduling and business management for salons, spas, barbershops, tattoo studios, nail salons, pet groomers, personal trainers, yoga studios, med spas, physiotherapy clinics, tutoring centers, and any appointment-based business. Like Salonist, Fresha, Square Appointments, or Vagaro. Features a day calendar with staff columns, service catalog, client management, product inventory, and blocked time slots.",
   "framework": "preact+hono",
   "files": [

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -4,7 +4,7 @@ import { query, get, run } from "./db.js";
 type Env = { Bindings: { DB: D1Database } };
 
 const app = createApp<Env>({
-  title: "Salon & Booking Manager",
+  title: "OpenSalon",
   version: "1.0.0",
   description: "Appointment scheduling and business management for salons, spas, and other appointment-based businesses.",
 });


### PR DESCRIPTION
Collapses the spaced product name into the single-word `OpenX` form, matching the OpenCut convention.

Display surfaces only: README, `clawnify.json` name, agent guide, app/API titles, `manifest.json`, UI strings.

Unchanged: repo slug, package name, app slug, D1 database names.