### PR TITLE
Checkout: tips, retail sales and per-staff takings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ data.db
 .DS_Store
 *.log
 .vite
+.wrangler

--- a/README.md
+++ b/README.md
@@ -41,13 +41,17 @@ OpenSalon is **vertical-agnostic** — configure services, pricing, and staff fo
 - **Client management** — full database with contact info, notes, preferences, and appointment history
 - **Staff management** — team directory with color coding, titles/roles, activate/deactivate, and appointment counts
 - **Service catalog** — configurable services with duration, price, color, and category grouping
+- **Checkout with built-in tipping** — close out an appointment on an itemised ticket: booked services, retail products added at the desk, a percentage or flat discount, preset (15/18/20%) or custom tips, and a payment method. Totals are priced on the server, so the browser can't set them
+- **Retail sold through the till** — add products to any ticket; stock is drawn down automatically and recorded in a `stock_movements` audit trail
+- **Staff takings report** — per staff member and per day: service revenue, retail revenue, discounts and tips, with a footer aggregate. This is the *booked vs taken* gap — appointments keep the quoted price, sales record what was actually paid
+- **Itemised receipts** — `GET /api/sales/:id` returns a full line-by-line receipt for one visit, with prices snapshotted at the time of sale
 - **Product inventory** — track retail products with cost/price, stock levels, low stock alerts, brand, and SKU
 - **Multi-service bookings** — select multiple services per appointment with automatic duration and price calculation
 - **Status workflow** — booked → confirmed → in progress → completed (or cancelled/no show)
 - **Activity notes** — timestamped notes on every appointment for internal communication
 - **Dashboard** — at-a-glance KPIs: today's appointments, upcoming count, revenue, client count, low stock alerts
 - **Search & filter** — find appointments by status, search clients by name/email/phone
-- **URL routing** — bookmarkable pages (`/calendar`, `/appointments/123`, `/clients`, `/staff`, `/services`, `/products`)
+- **URL routing** — bookmarkable pages (`/calendar`, `/appointments/123`, `/clients`, `/staff`, `/services`, `/products`, `/reports`)
 - **Dual-mode UI** — human-optimized + AI-agent-optimized (`?agent`)
 
 ## Quickstart
@@ -164,7 +168,28 @@ appointment_notes    (id, appointment_id, content)
 blocked_slots        (id, staff_id, blocked_date, start_time, end_time, reason)
 products             (id, name, brand, category, sku, price, cost, stock,
                       low_stock_alert)
+
+-- Checkout / till. A sale is what was taken; appointments.total_price stays
+-- what was quoted. `appointment_id` is nullable so a walk-in retail sale is a
+-- first-class sale with no booking behind it.
+sales                (id TEXT/uuid, status, appointment_id, client_id, staff_id,
+                      subtotal, discount, tip, total, payment_method, note,
+                      created_at, closed_at)
+sale_items           (id, sale_id, line_no, kind, ref_id, name, unit_price,
+                      qty, line_total)          -- name/price snapshotted
+stock_movements      (sale_id, product_id, qty) -- PK (sale_id, product_id);
+                                                -- the once-only stock guard
 ```
+
+**How a sale is written.** The database layer executes one statement per call
+and offers no multi-statement transaction, and foreign keys are enforced, so
+child rows can't be written before their parent. A sale is therefore written
+header-first as `status='open'`, then its lines, and the flip to `'closed'` is
+the commit point. Reports count closed sales only, which makes a half-written
+sale invisible rather than wrong. The `id` is a caller-minted UUID and doubles
+as an idempotency key — posting the same sale twice returns the original
+receipt instead of charging again, and `stock_movements` is keyed
+`(sale_id, product_id)` so a retried checkout can never draw stock twice.
 
 ### API Endpoints
 
@@ -200,10 +225,14 @@ products             (id, name, brand, category, sku, price, cost, stock,
 | POST | `/api/products` | Create a product |
 | PUT | `/api/products/:id` | Update a product |
 | DELETE | `/api/products/:id` | Delete a product |
+| POST | `/api/sales` | Ring up a ticket (idempotent on the caller-supplied `id`) |
+| GET | `/api/sales` | List closed sales (date / staff / client filters) |
+| GET | `/api/sales/:id` | Itemised receipt for one sale |
+| GET | `/api/reports/takings` | Takings per staff member and per day |
 
 ## SEO Keywords
 
-Open-source salon management software, free appointment booking software, open-source Salonist alternative, open-source Fresha alternative, free barbershop scheduling software, open-source Square Appointments alternative, open-source Vagaro alternative, free spa management software, open-source Booksy alternative, salon booking app, appointment scheduling software, staff scheduling software, beauty salon management, open-source booking system, free nail salon software, tattoo studio management, pet grooming software, self-hosted appointment booking, open-source salon POS, free yoga studio software, physiotherapy scheduling software, tutoring booking software, med spa management software.
+Open-source salon management software, free appointment booking software, open-source Salonist alternative, open-source Fresha alternative, free barbershop scheduling software, open-source Square Appointments alternative, open-source Vagaro alternative, free spa management software, open-source Booksy alternative, salon booking app, appointment scheduling software, staff scheduling software, beauty salon management, open-source booking system, free nail salon software, tattoo studio management, pet grooming software, self-hosted appointment booking, open-source salon POS, free yoga studio software, physiotherapy scheduling software, tutoring booking software, med spa management software, salon software with built-in tipping, salon staff targets software, salon commission tracking, salon checkout software, aesthetic clinic software with staff management, salon retail sales tracking, barbershop tip tracking software.
 
 ## Community & Contributions
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "wrangler d1 execute open-salon-db --local --file=src/server/schema.sql && concurrently -n ui,api -c cyan,green \"vite\" \"wrangler dev --port 8787\"",
-    "build": "vite build"
+    "build": "vite build",
+    "test": "node --experimental-strip-types --test src/server/*.test.ts"
   },
   "dependencies": {
     "@clawnify/app": "^0.1.0",

--- a/src/client/app.tsx
+++ b/src/client/app.tsx
@@ -12,6 +12,7 @@ import { ClientDetail } from "./components/client-detail";
 import { StaffList } from "./components/staff-list";
 import { ServiceList } from "./components/service-list";
 import { ProductList } from "./components/product-list";
+import { Reports } from "./components/reports";
 import { ErrorBanner } from "./components/error-banner";
 
 export function App() {
@@ -47,6 +48,7 @@ export function App() {
       case "staff": return <StaffList />;
       case "services": return <ServiceList />;
       case "products": return <ProductList />;
+      case "reports": return <Reports />;
       default: return <Dashboard />;
     }
   };

--- a/src/client/components/appointment-detail.tsx
+++ b/src/client/components/appointment-detail.tsx
@@ -1,7 +1,8 @@
 import { useState } from "preact/hooks";
 import { useApp } from "../context";
-import { ArrowLeft, Trash2, Send, Clock, User, DollarSign } from "lucide-preact";
+import { ArrowLeft, Trash2, Send, Clock, User, DollarSign, Receipt } from "lucide-preact";
 import { Button } from "@/components/ui/button";
+import { CheckoutDialog } from "./checkout-dialog";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -14,6 +15,7 @@ export function AppointmentDetail() {
     addAppointmentNote, deleteAppointmentNote, staffLookup,
   } = useApp();
   const [noteText, setNoteText] = useState("");
+  const [checkingOut, setCheckingOut] = useState(false);
 
   if (!apt) return null;
 
@@ -34,6 +36,11 @@ export function AppointmentDetail() {
         </Button>
         <h1 className="flex-1 text-2xl font-bold">{apt.identifier}</h1>
         <StatusBadge status={apt.status} />
+        {apt.status !== "completed" && apt.status !== "cancelled" && (
+          <Button size="sm" onClick={() => setCheckingOut(true)}>
+            <Receipt className="mr-1 h-3.5 w-3.5" /> Checkout
+          </Button>
+        )}
         <Button variant="destructive" size="sm" onClick={() => deleteAppointment(apt.id)}>
           <Trash2 className="mr-1 h-3.5 w-3.5" /> Delete
         </Button>
@@ -155,6 +162,10 @@ export function AppointmentDetail() {
           </Card>
         </div>
       </div>
+
+      {checkingOut && (
+        <CheckoutDialog appointment={apt} onClose={() => setCheckingOut(false)} />
+      )}
     </div>
   );
 }

--- a/src/client/components/checkout-dialog.tsx
+++ b/src/client/components/checkout-dialog.tsx
@@ -1,0 +1,404 @@
+import { useState, useMemo } from "preact/hooks";
+import { useApp } from "../context";
+import { Trash2, Receipt, Check } from "lucide-preact";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import type { Appointment } from "../types";
+// The same money module the server prices with. Importing it rather than
+// re-implementing the arithmetic here is what stops the figure on screen from
+// disagreeing with the figure that gets charged.
+import { priceSale, CheckoutError, type SaleItemInput, type Adjustment } from "../../server/checkout";
+
+const TIP_PRESETS = [15, 18, 20];
+const PAYMENT_METHODS = [
+  { value: "cash", label: "Cash" },
+  { value: "card", label: "Card" },
+  { value: "other", label: "Other" },
+] as const;
+
+/** 11px uppercase zone label — the house "eyebrow". */
+function Eyebrow({ children }: { children: preact.ComponentChildren }) {
+  return (
+    <p className="mb-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+      {children}
+    </p>
+  );
+}
+
+interface Props {
+  /** Omit for a walk-in sale — retail with no appointment behind it. */
+  appointment?: Appointment | null;
+  onClose: () => void;
+  onDone?: () => void;
+}
+
+export function CheckoutDialog({ appointment, onClose, onDone }: Props) {
+  const { products, services, staffLookup, clientLookup, recordSale, setError } = useApp();
+
+  // A fresh id per checkout. The server treats it as the idempotency key, so a
+  // double-submit or a retried request cannot ring the sale up twice.
+  const [saleId] = useState(() => crypto.randomUUID());
+
+  const [lines, setLines] = useState<SaleItemInput[]>(() =>
+    (appointment?.appointment_services ?? []).map((s) => ({
+      kind: "service" as const,
+      ref_id: s.service_id,
+      name: s.service_name || "Service",
+      unit_price: s.price,
+      qty: 1,
+    })),
+  );
+
+  const [staffId, setStaffId] = useState(appointment?.staff_id ? String(appointment.staff_id) : "");
+  const [clientId, setClientId] = useState(appointment?.client_id ? String(appointment.client_id) : "");
+
+  const [discountKind, setDiscountKind] = useState<"percent" | "amount">("percent");
+  const [discountValue, setDiscountValue] = useState("");
+  const [tipKind, setTipKind] = useState<"percent" | "amount">("percent");
+  const [tipValue, setTipValue] = useState("");
+  const [paymentMethod, setPaymentMethod] = useState<"cash" | "card" | "other">("card");
+  const [saving, setSaving] = useState(false);
+
+  const adjustment = (kind: "percent" | "amount", raw: string): Adjustment | undefined => {
+    const value = parseFloat(raw);
+    if (!raw.trim() || !Number.isFinite(value) || value <= 0) return undefined;
+    return { kind, value };
+  };
+
+  const discount = adjustment(discountKind, discountValue);
+  const tip = adjustment(tipKind, tipValue);
+
+  // Preview only. The server prices the sale again on submit and its answer is
+  // the one that counts — this exists so the desk can see the total first.
+  const preview = useMemo(() => {
+    try {
+      return { sale: priceSale({ items: lines, discount, tip, payment_method: paymentMethod }), problem: null };
+    } catch (err) {
+      return {
+        sale: null,
+        problem: err instanceof CheckoutError ? err.message : "This ticket does not add up",
+      };
+    }
+  }, [lines, discountKind, discountValue, tipKind, tipValue, paymentMethod]);
+
+  const addProduct = (productId: string) => {
+    const product = products.find((p) => p.id === Number(productId));
+    if (!product) return;
+    setLines((prev) => [
+      ...prev,
+      { kind: "product", ref_id: product.id, name: product.name, unit_price: product.price, qty: 1 },
+    ]);
+  };
+
+  const addService = (serviceId: string) => {
+    const service = services.find((s) => s.id === Number(serviceId));
+    if (!service) return;
+    setLines((prev) => [
+      ...prev,
+      { kind: "service", ref_id: service.id, name: service.name, unit_price: service.price, qty: 1 },
+    ]);
+  };
+
+  const setQty = (index: number, qty: number) =>
+    setLines((prev) => prev.map((l, i) => (i === index ? { ...l, qty: Math.max(1, qty) } : l)));
+
+  const removeLine = (index: number) => setLines((prev) => prev.filter((_, i) => i !== index));
+
+  const handleSubmit = async () => {
+    if (!preview.sale) { setError(preview.problem); return; }
+    setSaving(true);
+    try {
+      await recordSale({
+        id: saleId,
+        appointment_id: appointment?.id ?? null,
+        client_id: clientId ? Number(clientId) : null,
+        staff_id: staffId ? Number(staffId) : null,
+        items: lines,
+        discount,
+        tip,
+        payment_method: paymentMethod,
+      });
+      onDone?.();
+      onClose();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const money = (n: number) => `$${n.toFixed(2)}`;
+
+  return (
+    <Dialog open onOpenChange={(open: boolean) => !open && onClose()}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Receipt className="h-4 w-4" />
+            Checkout
+            {appointment && (
+              <span className="text-sm font-normal text-muted-foreground">
+                {appointment.identifier}
+                {appointment.client_name ? ` · ${appointment.client_name}` : ""}
+              </span>
+            )}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-5">
+          {/* ── Ticket ── */}
+          <div>
+            <Eyebrow>Ticket</Eyebrow>
+            {lines.length === 0 ? (
+              <p className="rounded-md border border-dashed py-6 text-center text-sm text-muted-foreground">
+                Nothing on the ticket yet
+              </p>
+            ) : (
+              <div className="divide-y rounded-md border">
+                {lines.map((line, i) => (
+                  <div key={`${line.kind}-${line.ref_id}-${i}`} className="flex items-center gap-2 px-3 py-2">
+                    <span
+                      className={cn(
+                        "shrink-0 rounded border px-1.5 py-0.5 text-[10px] uppercase tracking-wide",
+                        line.kind === "service"
+                          ? "border-border bg-muted text-muted-foreground"
+                          : "border-border bg-background text-muted-foreground",
+                      )}
+                    >
+                      {line.kind === "service" ? "Svc" : "Retail"}
+                    </span>
+                    <span className="flex-1 truncate text-sm">{line.name}</span>
+                    {line.kind === "product" ? (
+                      <Input
+                        type="number"
+                        min={1}
+                        className="h-7 w-14 text-center text-sm"
+                        value={String(line.qty)}
+                        onChange={(e: Event) => setQty(i, parseInt((e.target as HTMLInputElement).value, 10) || 1)}
+                      />
+                    ) : (
+                      <span className="w-14 text-center text-xs text-muted-foreground">&times;1</span>
+                    )}
+                    <span className="w-20 text-right text-sm tabular-nums">
+                      {money(line.unit_price * line.qty)}
+                    </span>
+                    <button
+                      className="text-muted-foreground transition-colors hover:text-destructive"
+                      aria-label={`Remove ${line.name}`}
+                      onClick={() => removeLine(i)}
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div className="mt-2 grid grid-cols-2 gap-2">
+              <label className="sr-only" for="checkout-add-service">Add a service</label>
+              <select
+                id="checkout-add-service"
+                className="flex h-9 w-full rounded-md border border-input bg-background px-2 text-sm"
+                value=""
+                onChange={(e: Event) => { addService((e.target as HTMLSelectElement).value); (e.target as HTMLSelectElement).value = ""; }}
+              >
+                <option value="">+ Add service</option>
+                {services.filter((s) => s.active).map((s) => (
+                  <option key={s.id} value={s.id}>{s.name} &mdash; ${s.price.toFixed(2)}</option>
+                ))}
+              </select>
+              <label className="sr-only" for="checkout-add-product">Add a retail product</label>
+              <select
+                id="checkout-add-product"
+                className="flex h-9 w-full rounded-md border border-input bg-background px-2 text-sm"
+                value=""
+                onChange={(e: Event) => { addProduct((e.target as HTMLSelectElement).value); (e.target as HTMLSelectElement).value = ""; }}
+              >
+                <option value="">+ Add retail</option>
+                {products.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name} &mdash; ${p.price.toFixed(2)}{p.stock <= 0 ? " (out of stock)" : ""}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          {/* ── Who ── */}
+          <div>
+            <Eyebrow>Attributed to</Eyebrow>
+            <div className="grid grid-cols-2 gap-2">
+              <div className="space-y-1.5">
+                <Label className="text-xs text-muted-foreground">Staff</Label>
+                <select
+                  className="flex h-9 w-full rounded-md border border-input bg-background px-2 text-sm"
+                  value={staffId}
+                  onChange={(e: Event) => setStaffId((e.target as HTMLSelectElement).value)}
+                >
+                  <option value="">Unassigned</option>
+                  {staffLookup.map((s) => <option key={s.id} value={s.id}>{s.name}</option>)}
+                </select>
+              </div>
+              <div className="space-y-1.5">
+                <Label className="text-xs text-muted-foreground">Client</Label>
+                <select
+                  className="flex h-9 w-full rounded-md border border-input bg-background px-2 text-sm"
+                  value={clientId}
+                  onChange={(e: Event) => setClientId((e.target as HTMLSelectElement).value)}
+                >
+                  <option value="">Walk-in</option>
+                  {clientLookup.map((cl) => <option key={cl.id} value={cl.id}>{cl.name}</option>)}
+                </select>
+              </div>
+            </div>
+          </div>
+
+          {/* ── Adjustments ── */}
+          <div>
+            <Eyebrow>Discount &amp; tip</Eyebrow>
+            <div className="space-y-3">
+              <div className="flex items-center gap-2">
+                <Label className="w-16 text-xs text-muted-foreground">Discount</Label>
+                <div className="flex overflow-hidden rounded-md border">
+                  {(["percent", "amount"] as const).map((k) => (
+                    <button
+                      key={k}
+                      className={cn(
+                        "px-2 py-1.5 text-xs transition-colors",
+                        discountKind === k ? "bg-muted font-medium" : "text-muted-foreground hover:bg-muted/50",
+                      )}
+                      onClick={() => setDiscountKind(k)}
+                    >
+                      {k === "percent" ? "%" : "$"}
+                    </button>
+                  ))}
+                </div>
+                <Input
+                  type="number"
+                  min={0}
+                  step="0.01"
+                  placeholder="0"
+                  className="h-8 flex-1 text-sm"
+                  value={discountValue}
+                  onChange={(e: Event) => setDiscountValue((e.target as HTMLInputElement).value)}
+                />
+              </div>
+
+              <div className="flex items-center gap-2">
+                <Label className="w-16 text-xs text-muted-foreground">Tip</Label>
+                <div className="flex gap-1">
+                  {TIP_PRESETS.map((pct) => {
+                    const active = tipKind === "percent" && tipValue === String(pct);
+                    return (
+                      <button
+                        key={pct}
+                        className={cn(
+                          "rounded-md border px-2 py-1.5 text-xs transition-colors",
+                          active
+                            ? "border-primary bg-primary/5 font-medium text-primary"
+                            : "border-border text-muted-foreground hover:border-primary/50",
+                        )}
+                        onClick={() => {
+                          setTipKind("percent");
+                          setTipValue(active ? "" : String(pct));
+                        }}
+                      >
+                        {pct}%
+                      </button>
+                    );
+                  })}
+                </div>
+                <div className="flex overflow-hidden rounded-md border">
+                  {(["percent", "amount"] as const).map((k) => (
+                    <button
+                      key={k}
+                      className={cn(
+                        "px-2 py-1.5 text-xs transition-colors",
+                        tipKind === k ? "bg-muted font-medium" : "text-muted-foreground hover:bg-muted/50",
+                      )}
+                      onClick={() => setTipKind(k)}
+                    >
+                      {k === "percent" ? "%" : "$"}
+                    </button>
+                  ))}
+                </div>
+                <Input
+                  type="number"
+                  min={0}
+                  step="0.01"
+                  placeholder="0"
+                  className="h-8 flex-1 text-sm"
+                  value={tipValue}
+                  onChange={(e: Event) => setTipValue((e.target as HTMLInputElement).value)}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* ── Payment ── */}
+          <div>
+            <Eyebrow>Payment</Eyebrow>
+            <div className="flex gap-1.5">
+              {PAYMENT_METHODS.map((m) => (
+                <button
+                  key={m.value}
+                  className={cn(
+                    "flex flex-1 items-center justify-center gap-1.5 rounded-md border px-3 py-2 text-sm transition-colors",
+                    paymentMethod === m.value
+                      ? "border-primary bg-primary/5 font-medium text-primary"
+                      : "border-border text-muted-foreground hover:border-primary/50",
+                  )}
+                  onClick={() => setPaymentMethod(m.value)}
+                >
+                  {paymentMethod === m.value && <Check className="h-3.5 w-3.5" strokeWidth={2.5} />}
+                  {m.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* ── Totals ── */}
+          <div className="rounded-md border bg-muted/30 px-3 py-2.5">
+            <Eyebrow>Total</Eyebrow>
+            {preview.sale ? (
+              <dl className="space-y-1 text-sm">
+                <div className="flex justify-between">
+                  <dt className="text-muted-foreground">Subtotal</dt>
+                  <dd className="tabular-nums">{money(preview.sale.subtotal)}</dd>
+                </div>
+                {preview.sale.discount > 0 && (
+                  <div className="flex justify-between">
+                    <dt className="text-muted-foreground">Discount</dt>
+                    <dd className="tabular-nums text-amber-600">&minus;{money(preview.sale.discount)}</dd>
+                  </div>
+                )}
+                {preview.sale.tip > 0 && (
+                  <div className="flex justify-between">
+                    <dt className="text-muted-foreground">Tip</dt>
+                    <dd className="tabular-nums">{money(preview.sale.tip)}</dd>
+                  </div>
+                )}
+                <div className="flex justify-between border-t pt-1 text-base font-bold">
+                  <dt>Total</dt>
+                  <dd className="tabular-nums">{money(preview.sale.total)}</dd>
+                </div>
+              </dl>
+            ) : (
+              <p className="text-sm text-destructive">{preview.problem}</p>
+            )}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>Cancel</Button>
+          <Button disabled={saving || !preview.sale} onClick={handleSubmit}>
+            {saving ? "Recording..." : "Complete sale"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/client/components/reports.tsx
+++ b/src/client/components/reports.tsx
@@ -1,0 +1,181 @@
+import { useEffect } from "preact/hooks";
+import { useApp } from "../context";
+import { Scissors, ShoppingBag, Coins, Wallet } from "lucide-preact";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Table, TableBody, TableCell, TableFooter, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+const money = (n: number) => `$${n.toFixed(2)}`;
+
+/** 11px uppercase zone label — the house "eyebrow". */
+function Eyebrow({ children }: { children: preact.ComponentChildren }) {
+  return (
+    <p className="mb-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+      {children}
+    </p>
+  );
+}
+
+export function Reports() {
+  const { takings, takingsRange, setTakingsRange, loadTakings } = useApp();
+
+  useEffect(() => { void loadTakings(); }, [loadTakings]);
+
+  const totals = takings?.totals;
+
+  // Retail as a share of the till. The number salon owners actually chase —
+  // service revenue is capped by hours in the day, retail is not.
+  const retailShare = totals && totals.total > 0
+    ? Math.round((totals.retail_revenue / totals.total) * 100)
+    : 0;
+
+  const cards = [
+    { label: "Service revenue", value: money(totals?.service_revenue ?? 0), meta: `${totals?.sale_count ?? 0} sales`, icon: Scissors, tone: "text-violet-600 bg-violet-50" },
+    { label: "Retail revenue", value: money(totals?.retail_revenue ?? 0), meta: `${retailShare}% of takings`, icon: ShoppingBag, tone: "text-emerald-600 bg-emerald-50" },
+    { label: "Tips", value: money(totals?.tips ?? 0), meta: "paid to staff", icon: Coins, tone: "text-amber-600 bg-amber-50" },
+    { label: "Total taken", value: money(totals?.total ?? 0), meta: totals && totals.discount > 0 ? `after ${money(totals.discount)} discounts` : "no discounts", icon: Wallet, tone: "text-blue-600 bg-blue-50" },
+  ];
+
+  return (
+    <div className="space-y-6 p-6">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Reports</h1>
+          <p className="text-sm text-muted-foreground">
+            What was actually taken, not what was booked.
+          </p>
+        </div>
+        <div className="flex items-end gap-2">
+          <div className="space-y-1.5">
+            <Label className="text-xs text-muted-foreground" for="takings-from">From</Label>
+            <Input
+              id="takings-from"
+              type="date"
+              className="h-9 w-[9.5rem]"
+              value={takingsRange.from}
+              onChange={(e: Event) => setTakingsRange({ ...takingsRange, from: (e.target as HTMLInputElement).value })}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-xs text-muted-foreground" for="takings-to">To</Label>
+            <Input
+              id="takings-to"
+              type="date"
+              className="h-9 w-[9.5rem]"
+              value={takingsRange.to}
+              onChange={(e: Event) => setTakingsRange({ ...takingsRange, to: (e.target as HTMLInputElement).value })}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        {cards.map((card) => (
+          <Card key={card.label}>
+            <CardContent className="flex items-center gap-3 p-4">
+              <div className={`flex h-10 w-10 items-center justify-center rounded-lg ${card.tone}`}>
+                <card.icon className="h-5 w-5" />
+              </div>
+              <div className="min-w-0">
+                <div className="text-xl font-bold tabular-nums">{card.value}</div>
+                <div className="truncate text-xs text-muted-foreground">{card.label}</div>
+                {/* Fixed height so the meta line appearing never shifts the row. */}
+                <div className="h-4 truncate text-[11px] text-muted-foreground/70">{card.meta}</div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <div>
+        <Eyebrow>By staff member</Eyebrow>
+        {!takings || takings.staff.length === 0 ? (
+          <p className="rounded-md border border-dashed py-10 text-center text-sm text-muted-foreground">
+            No sales in this period. Check an appointment out to start recording takings.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Staff</TableHead>
+                  <TableHead className="w-20 text-right">Sales</TableHead>
+                  <TableHead className="w-28 text-right">Services</TableHead>
+                  <TableHead className="w-28 text-right">Retail</TableHead>
+                  <TableHead className="w-28 text-right">Tips</TableHead>
+                  <TableHead className="w-28 text-right">Total</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {takings.staff.map((row) => (
+                  <TableRow key={row.staff_id ?? "none"}>
+                    <TableCell className="font-medium">
+                      <span className="flex items-center gap-2">
+                        <span
+                          className="inline-block h-2 w-2 rounded-full"
+                          style={{ backgroundColor: row.staff_color }}
+                        />
+                        {row.staff_name}
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">{row.sale_count}</TableCell>
+                    <TableCell className="text-right tabular-nums">{money(row.service_revenue)}</TableCell>
+                    <TableCell className="text-right tabular-nums">{money(row.retail_revenue)}</TableCell>
+                    <TableCell className="text-right tabular-nums">{money(row.tips)}</TableCell>
+                    <TableCell className="text-right font-medium tabular-nums">{money(row.total)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+              {/* Footer aggregate — a numeric table should always sum itself. */}
+              <TableFooter>
+                <TableRow>
+                  <TableCell className="font-medium">All staff</TableCell>
+                  <TableCell className="text-right tabular-nums">{totals?.sale_count ?? 0}</TableCell>
+                  <TableCell className="text-right tabular-nums">{money(totals?.service_revenue ?? 0)}</TableCell>
+                  <TableCell className="text-right tabular-nums">{money(totals?.retail_revenue ?? 0)}</TableCell>
+                  <TableCell className="text-right tabular-nums">{money(totals?.tips ?? 0)}</TableCell>
+                  <TableCell className="text-right font-bold tabular-nums">{money(totals?.total ?? 0)}</TableCell>
+                </TableRow>
+              </TableFooter>
+            </Table>
+          </div>
+        )}
+      </div>
+
+      {takings && takings.days.length > 0 && (
+        <div>
+          <Eyebrow>By day</Eyebrow>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Date</TableHead>
+                  <TableHead className="w-20 text-right">Sales</TableHead>
+                  <TableHead className="w-28 text-right">Subtotal</TableHead>
+                  <TableHead className="w-28 text-right">Discounts</TableHead>
+                  <TableHead className="w-28 text-right">Tips</TableHead>
+                  <TableHead className="w-28 text-right">Total</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {takings.days.map((day) => (
+                  <TableRow key={day.date}>
+                    <TableCell className="font-medium">{day.date}</TableCell>
+                    <TableCell className="text-right tabular-nums">{day.sale_count}</TableCell>
+                    <TableCell className="text-right tabular-nums">{money(day.subtotal)}</TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {day.discount > 0 ? `−${money(day.discount)}` : "—"}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">{money(day.tips)}</TableCell>
+                    <TableCell className="text-right font-medium tabular-nums">{money(day.total)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/client/components/sidebar.tsx
+++ b/src/client/components/sidebar.tsx
@@ -1,5 +1,5 @@
 import { useApp } from "../context";
-import { Scissors, LayoutDashboard, CalendarDays, Clock, Users, UserCog, Sparkles, Package } from "lucide-preact";
+import { Scissors, LayoutDashboard, CalendarDays, Clock, Users, UserCog, Sparkles, Package, BarChart3 } from "lucide-preact";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
@@ -13,6 +13,7 @@ const navItems: { view: View; path: string; label: string; icon: typeof LayoutDa
   { view: "staff", path: "/staff", label: "Staff", icon: UserCog },
   { view: "services", path: "/services", label: "Services", icon: Sparkles },
   { view: "products", path: "/products", label: "Products", icon: Package },
+  { view: "reports", path: "/reports", label: "Reports", icon: BarChart3 },
 ];
 
 export function Sidebar({ currentView }: { currentView: View }) {

--- a/src/client/context.tsx
+++ b/src/client/context.tsx
@@ -2,7 +2,7 @@ import { createContext } from "preact";
 import { useContext } from "preact/hooks";
 import type {
   Appointment, Client, Staff, Service, Product, BlockedSlot, Stats, PaginatedState,
-  ClientLookup, StaffLookup,
+  ClientLookup, StaffLookup, TakingsReport, DateRange, Sale,
 } from "./types";
 
 export interface AppContextValue {
@@ -83,6 +83,13 @@ export interface AppContextValue {
   // Lookups
   clientLookup: ClientLookup[];
   staffLookup: StaffLookup[];
+
+  // Checkout / till
+  takings: TakingsReport | null;
+  takingsRange: DateRange;
+  setTakingsRange: (r: DateRange) => void;
+  loadTakings: () => Promise<void>;
+  recordSale: (payload: Record<string, unknown>) => Promise<Sale>;
 
   loading: boolean;
   error: string | null;

--- a/src/client/hooks/use-app.ts
+++ b/src/client/hooks/use-app.ts
@@ -2,7 +2,7 @@ import { useState, useCallback, useEffect } from "preact/hooks";
 import { api } from "../api";
 import type {
   Appointment, Client, Staff, Service, Product, BlockedSlot, Stats, PaginatedState,
-  ClientLookup, StaffLookup,
+  ClientLookup, StaffLookup, TakingsReport, DateRange, Sale,
 } from "../types";
 import type { AppContextValue } from "../context";
 
@@ -39,6 +39,11 @@ export function useAppState(isAgent: boolean, navigate: (to: string) => void): A
   const [products, setProducts] = useState<Product[]>([]);
   const [productsPag, setProductsPag] = useState<PaginatedState>({ page: 1, limit: 50, total: 0 });
   const [productsSearch, setProductsSearch] = useState("");
+
+  // ── Takings ──
+  const monthStart = `${todayStr.slice(0, 7)}-01`;
+  const [takings, setTakings] = useState<TakingsReport | null>(null);
+  const [takingsRange, setTakingsRange] = useState<DateRange>({ from: monthStart, to: todayStr });
 
   // Lookups
   const [clientLookup, setClientLookup] = useState<ClientLookup[]>([]);
@@ -302,6 +307,33 @@ export function useAppState(isAgent: boolean, navigate: (to: string) => void): A
     await fetchStats();
   }, [productsPag, productsSearch, fetchProducts, fetchStats]);
 
+  // ── Checkout ──
+
+  const loadTakings = useCallback(async () => {
+    const q = new URLSearchParams({ from: takingsRange.from, to: takingsRange.to });
+    const data = await api<TakingsReport>("GET", `/api/reports/takings?${q}`);
+    setTakings(data);
+  }, [takingsRange]);
+
+  const recordSale = useCallback(async (payload: Record<string, unknown>) => {
+    const { sale } = await api<{ sale: Sale }>("POST", "/api/sales", payload);
+    // A sale moves three things at once: the appointment is completed, retail
+    // stock is drawn down, and the takings change. Refresh all of them.
+    await Promise.all([
+      fetchStats(),
+      fetchProducts(productsPag, productsSearch),
+      loadTakings(),
+    ]);
+    if (payload.appointment_id) {
+      await Promise.all([
+        fetchAppointments(appointmentsPag, appointmentsSearch, appointmentsStatusFilter),
+        selectAppointment(Number(payload.appointment_id)),
+      ]);
+    }
+    return sale;
+  }, [fetchStats, fetchProducts, productsPag, productsSearch, loadTakings,
+      fetchAppointments, appointmentsPag, appointmentsSearch, appointmentsStatusFilter, selectAppointment]);
+
   return {
     navigate, isAgent, stats,
     appointments, appointmentsPag, setAppointmentsPage, appointmentsSearch, setAppointmentsSearch,
@@ -318,6 +350,7 @@ export function useAppState(isAgent: boolean, navigate: (to: string) => void): A
     products, productsPag, setProductsPage, productsSearch, setProductsSearch,
     addProduct, updateProduct, deleteProduct,
     clientLookup, staffLookup,
+    takings, takingsRange, setTakingsRange, loadTakings, recordSale,
     loading, error, setError,
   };
 }

--- a/src/client/hooks/use-router.ts
+++ b/src/client/hooks/use-router.ts
@@ -15,6 +15,7 @@ const VIEW_ROUTES: Record<string, View> = {
   "staff": "staff",
   "services": "services",
   "products": "products",
+  "reports": "reports",
 };
 
 function parseRoute(path: string): RouteState {

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,4 +1,4 @@
-export type View = "dashboard" | "calendar" | "appointments" | "clients" | "staff" | "services" | "products";
+export type View = "dashboard" | "calendar" | "appointments" | "clients" | "staff" | "services" | "products" | "reports";
 
 export type AppointmentStatus = "booked" | "confirmed" | "in_progress" | "completed" | "cancelled" | "no_show";
 
@@ -130,3 +130,75 @@ export interface StaffLookup {
   name: string;
   color: string;
 }
+
+// ── Checkout / till ───────────────────────────────────────────────────
+
+export interface SaleItem {
+  id: number;
+  sale_id: string;
+  line_no: number;
+  kind: "service" | "product";
+  ref_id: number | null;
+  name: string;
+  unit_price: number;
+  qty: number;
+  line_total: number;
+}
+
+export interface Sale {
+  id: string;
+  status: string;
+  appointment_id: number | null;
+  client_id: number | null;
+  staff_id: number | null;
+  subtotal: number;
+  discount: number;
+  tip: number;
+  total: number;
+  payment_method: string;
+  note: string;
+  created_at: string;
+  closed_at: string | null;
+  client_name?: string | null;
+  staff_name?: string | null;
+  appointment_identifier?: string | null;
+  items?: SaleItem[];
+}
+
+export interface StaffTakings {
+  staff_id: number | null;
+  staff_name: string;
+  staff_color: string;
+  sale_count: number;
+  service_revenue: number;
+  retail_revenue: number;
+  discount: number;
+  tips: number;
+  total: number;
+}
+
+export interface DayTakings {
+  date: string;
+  sale_count: number;
+  subtotal: number;
+  discount: number;
+  tips: number;
+  total: number;
+}
+
+export interface TakingsReport {
+  from: string;
+  to: string;
+  totals: {
+    sale_count: number;
+    service_revenue: number;
+    retail_revenue: number;
+    discount: number;
+    tips: number;
+    total: number;
+  };
+  staff: StaffTakings[];
+  days: DayTakings[];
+}
+
+export interface DateRange { from: string; to: string }

--- a/src/server/checkout.test.ts
+++ b/src/server/checkout.test.ts
@@ -1,0 +1,221 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { priceSale, stockDraw, CheckoutError, type SaleInput } from "./checkout.ts";
+
+const service = (name: string, price: number) => ({
+  kind: "service" as const,
+  ref_id: 1,
+  name,
+  unit_price: price,
+  qty: 1,
+});
+
+const product = (id: number, name: string, price: number, qty = 1) => ({
+  kind: "product" as const,
+  ref_id: id,
+  name,
+  unit_price: price,
+  qty,
+});
+
+const base = (over: Partial<SaleInput> = {}): SaleInput => ({
+  items: [service("Standard Session", 50)],
+  payment_method: "cash",
+  ...over,
+});
+
+test("prices a plain single-service ticket", () => {
+  const s = priceSale(base());
+  assert.equal(s.subtotal, 50);
+  assert.equal(s.discount, 0);
+  assert.equal(s.tip, 0);
+  assert.equal(s.total, 50);
+});
+
+test("the worked example from the design holds end to end", () => {
+  // Cut & Style 50 + Express Touch-up 20 + shampoo 24.99 = 94.99
+  // less 10% (9.50) = 85.49, plus a 20% tip (17.10) = 102.59
+  const s = priceSale({
+    items: [
+      service("Cut & Style", 50),
+      { kind: "service", ref_id: 4, name: "Express Touch-up", unit_price: 20, qty: 1 },
+      product(1, "Professional Shampoo", 24.99),
+    ],
+    discount: { kind: "percent", value: 10 },
+    tip: { kind: "percent", value: 20 },
+    payment_method: "card",
+  });
+  assert.equal(s.subtotal, 94.99);
+  assert.equal(s.discount, 9.5);
+  assert.equal(s.net, 85.49);
+  assert.equal(s.tip, 17.1);
+  assert.equal(s.total, 102.59);
+});
+
+test("a percentage tip is taken on the post-discount figure, not the subtotal", () => {
+  const s = priceSale(base({
+    items: [service("Session", 100)],
+    discount: { kind: "amount", value: 50 },
+    tip: { kind: "percent", value: 20 },
+  }));
+  assert.equal(s.tip, 10, "20% of 50, not 20% of 100");
+  assert.equal(s.total, 60);
+});
+
+test("flat discount and flat tip are taken verbatim", () => {
+  const s = priceSale(base({
+    items: [service("Session", 80)],
+    discount: { kind: "amount", value: 12.5 },
+    tip: { kind: "amount", value: 7.25 },
+  }));
+  assert.equal(s.discount, 12.5);
+  assert.equal(s.net, 67.5);
+  assert.equal(s.tip, 7.25);
+  assert.equal(s.total, 74.75);
+});
+
+test("many awkward lines still total to the cent", () => {
+  // Six lines that each round badly in binary floating point. Summing these
+  // as floats drifts; summing as cents does not.
+  const s = priceSale(base({
+    items: Array.from({ length: 6 }, (_, i) => product(i + 1, `Item ${i + 1}`, 0.07)),
+  }));
+  assert.equal(s.subtotal, 0.42);
+  assert.equal(s.total, 0.42);
+});
+
+test("a repeated-price ticket does not drift", () => {
+  const s = priceSale(base({
+    items: [product(1, "Cream", 32.99, 3), product(2, "Oil", 45.99, 7)],
+  }));
+  // 98.97 + 321.93
+  assert.equal(s.subtotal, 420.9);
+});
+
+test("percentages round to the nearest cent", () => {
+  const s = priceSale(base({
+    items: [service("Session", 33.33)],
+    discount: { kind: "percent", value: 15 },
+  }));
+  // 15% of 3333c = 499.95c -> 500c
+  assert.equal(s.discount, 5);
+  assert.equal(s.net, 28.33);
+});
+
+test("a 100% discount is allowed and zeroes the ticket", () => {
+  const s = priceSale(base({ discount: { kind: "percent", value: 100 } }));
+  assert.equal(s.discount, 50);
+  assert.equal(s.net, 0);
+  assert.equal(s.total, 0);
+});
+
+test("a tip on a fully discounted ticket is still honoured", () => {
+  const s = priceSale(base({
+    discount: { kind: "percent", value: 100 },
+    tip: { kind: "amount", value: 5 },
+  }));
+  assert.equal(s.net, 0);
+  assert.equal(s.tip, 5);
+  assert.equal(s.total, 5);
+});
+
+// ── Trust boundary ────────────────────────────────────────────────────
+// The browser sends intent; these are the things it must not be able to talk
+// the server into.
+
+test("an empty ticket is refused", () => {
+  assert.throws(() => priceSale(base({ items: [] })), CheckoutError);
+});
+
+test("a discount larger than the subtotal is refused", () => {
+  assert.throws(
+    () => priceSale(base({ discount: { kind: "amount", value: 50.01 } })),
+    /discount cannot exceed the subtotal/,
+  );
+});
+
+test("a percentage over 100 is refused", () => {
+  assert.throws(
+    () => priceSale(base({ discount: { kind: "percent", value: 101 } })),
+    /cannot exceed 100/,
+  );
+});
+
+test("negative money is refused", () => {
+  assert.throws(() => priceSale(base({ tip: { kind: "amount", value: -1 } })), /negative/);
+  assert.throws(
+    () => priceSale(base({ items: [{ ...service("S", -5) }] })),
+    /invalid price/,
+  );
+});
+
+test("non-finite money is refused", () => {
+  assert.throws(() => priceSale(base({ tip: { kind: "amount", value: NaN } })), /must be a number/);
+  assert.throws(
+    () => priceSale(base({ items: [{ ...service("S", Infinity) }] })),
+    /invalid price/,
+  );
+});
+
+test("fractional and zero quantities are refused", () => {
+  assert.throws(() => priceSale(base({ items: [product(1, "Cream", 10, 1.5)] })), /whole quantity/);
+  assert.throws(() => priceSale(base({ items: [product(1, "Cream", 10, 0)] })), /whole quantity/);
+});
+
+test("a nameless line is refused", () => {
+  assert.throws(() => priceSale(base({ items: [{ ...service("   ", 10) }] })), /needs a name/);
+});
+
+test("an unknown line kind is refused", () => {
+  assert.throws(
+    () => priceSale(base({ items: [{ ...service("S", 10), kind: "tip" as never }] })),
+    /line kind must be/,
+  );
+});
+
+test("an unknown payment method is refused", () => {
+  assert.throws(
+    () => priceSale(base({ payment_method: "crypto" as never })),
+    /payment_method must be one of/,
+  );
+});
+
+test("a service cannot be rung up more than once", () => {
+  assert.throws(
+    () => priceSale(base({ items: [{ ...service("Session", 50), qty: 2 }] })),
+    /quantity must be 1/,
+  );
+});
+
+test("line names are trimmed and a missing ref becomes null", () => {
+  const s = priceSale(base({
+    items: [{ kind: "product", name: "  Loose item  ", unit_price: 3, qty: 1 }],
+  }));
+  assert.equal(s.lines[0].name, "Loose item");
+  assert.equal(s.lines[0].ref_id, null);
+});
+
+// ── Stock draw ────────────────────────────────────────────────────────
+
+test("stock draw ignores services and keeps products", () => {
+  const s = priceSale(base({
+    items: [service("Session", 50), product(7, "Gel", 15.99, 2)],
+  }));
+  assert.deepEqual(stockDraw(s.lines), [{ product_id: 7, qty: 2 }]);
+});
+
+test("the same product on two lines is summed into one movement", () => {
+  // (sale_id, product_id) is the primary key of stock_movements, so writing
+  // two rows for one product would fail and leave the stock short.
+  const s = priceSale(base({
+    items: [product(7, "Gel", 15.99, 2), product(7, "Gel", 15.99, 3)],
+  }));
+  assert.deepEqual(stockDraw(s.lines), [{ product_id: 7, qty: 5 }]);
+});
+
+test("an untracked product line draws no stock", () => {
+  const s = priceSale(base({
+    items: [{ kind: "product", name: "Ad-hoc item", unit_price: 5, qty: 1 }],
+  }));
+  assert.deepEqual(stockDraw(s.lines), []);
+});

--- a/src/server/checkout.ts
+++ b/src/server/checkout.ts
@@ -1,0 +1,158 @@
+// Money math for the till. Pure — no database, no Hono — so the arithmetic
+// that decides what a client is charged can be tested on its own.
+//
+// Everything is computed in integer cents and only converted back to a
+// decimal at the edges. The columns are REAL (to match `services.price` and
+// `appointments.total_price`), but accumulating a ticket in floating point is
+// how you end up a cent out on a six-line sale.
+
+export type ItemKind = "service" | "product";
+
+export type PaymentMethod = "cash" | "card" | "other";
+
+export const PAYMENT_METHODS: PaymentMethod[] = ["cash", "card", "other"];
+
+/** A percentage of the ticket, or a flat cash figure. */
+export type Adjustment = { kind: "percent" | "amount"; value: number };
+
+export interface SaleItemInput {
+  kind: ItemKind;
+  /** services.id or products.id. Kept for reporting; the line stands without it. */
+  ref_id?: number | null;
+  /** Snapshotted, so the receipt still reads correctly after a catalogue edit. */
+  name: string;
+  unit_price: number;
+  qty: number;
+}
+
+export interface SaleInput {
+  items: SaleItemInput[];
+  discount?: Adjustment;
+  tip?: Adjustment;
+  payment_method: PaymentMethod;
+}
+
+export interface PricedLine extends SaleItemInput {
+  line_total: number;
+}
+
+export interface PricedSale {
+  lines: PricedLine[];
+  subtotal: number;
+  discount: number;
+  /** Subtotal less discount. Not stored — the base the tip is taken on. */
+  net: number;
+  tip: number;
+  total: number;
+}
+
+const toCents = (n: number): number => Math.round(n * 100);
+const toMoney = (cents: number): number => cents / 100;
+
+/** Percentage of a cent amount, rounded to the nearest cent. */
+const pctOf = (cents: number, percent: number): number =>
+  Math.round((cents * percent) / 100);
+
+/** Rounds a decimal to cents. For summing figures already stored as REAL. */
+export const round2 = (n: number): number => Math.round(n * 100) / 100;
+
+export class CheckoutError extends Error {}
+
+function fail(message: string): never {
+  throw new CheckoutError(message);
+}
+
+function resolve(adj: Adjustment | undefined, baseCents: number, label: string): number {
+  if (!adj) return 0;
+  if (!Number.isFinite(adj.value)) fail(`${label} must be a number`);
+  if (adj.value < 0) fail(`${label} cannot be negative`);
+  if (adj.kind === "percent") {
+    if (adj.value > 100) fail(`${label} percentage cannot exceed 100`);
+    return pctOf(baseCents, adj.value);
+  }
+  if (adj.kind !== "amount") fail(`${label} kind must be "percent" or "amount"`);
+  return toCents(adj.value);
+}
+
+/**
+ * Prices a ticket. This is the authoritative calculation: the client sends
+ * intent ("20% tip") and the server decides the number, so a tampered or
+ * simply stale browser cannot dictate the total.
+ *
+ * A percentage tip is taken on the post-discount figure, which is what the
+ * front desk expects — discount the service, then tip on what's actually owed.
+ */
+export function priceSale(input: SaleInput): PricedSale {
+  if (!Array.isArray(input.items) || input.items.length === 0) {
+    fail("a sale needs at least one line");
+  }
+  if (!PAYMENT_METHODS.includes(input.payment_method)) {
+    fail(`payment_method must be one of ${PAYMENT_METHODS.join(", ")}`);
+  }
+
+  const lines: PricedLine[] = [];
+  let subtotalCents = 0;
+
+  for (const item of input.items) {
+    if (item.kind !== "service" && item.kind !== "product") {
+      fail(`line kind must be "service" or "product", got "${item.kind}"`);
+    }
+    const name = (item.name ?? "").trim();
+    if (!name) fail("every line needs a name");
+    if (!Number.isFinite(item.unit_price) || item.unit_price < 0) {
+      fail(`"${name}" has an invalid price`);
+    }
+    if (!Number.isInteger(item.qty) || item.qty < 1) {
+      fail(`"${name}" needs a whole quantity of at least 1`);
+    }
+    // A service is the appointment's own work: one of it, by definition.
+    if (item.kind === "service" && item.qty !== 1) {
+      fail(`"${name}" is a service, so its quantity must be 1`);
+    }
+
+    const lineCents = toCents(item.unit_price) * item.qty;
+    subtotalCents += lineCents;
+    lines.push({
+      ...item,
+      name,
+      ref_id: item.ref_id ?? null,
+      line_total: toMoney(lineCents),
+    });
+  }
+
+  const discountCents = resolve(input.discount, subtotalCents, "discount");
+  if (discountCents > subtotalCents) {
+    fail("discount cannot exceed the subtotal");
+  }
+
+  const netCents = subtotalCents - discountCents;
+  const tipCents = resolve(input.tip, netCents, "tip");
+  const totalCents = netCents + tipCents;
+
+  return {
+    lines,
+    subtotal: toMoney(subtotalCents),
+    discount: toMoney(discountCents),
+    net: toMoney(netCents),
+    tip: toMoney(tipCents),
+    total: toMoney(totalCents),
+  };
+}
+
+/**
+ * Collapses the product lines to one quantity per product.
+ *
+ * `stock_movements` is keyed on (sale_id, product_id) so that recording a
+ * movement can only succeed once per sale — that uniqueness is what makes the
+ * stock decrement safe to retry. The same product appearing on two lines has
+ * to be summed here rather than written twice.
+ */
+export function stockDraw(lines: PricedLine[]): Array<{ product_id: number; qty: number }> {
+  const byProduct = new Map<number, number>();
+  for (const line of lines) {
+    if (line.kind !== "product") continue;
+    if (typeof line.ref_id !== "number") continue;
+    byProduct.set(line.ref_id, (byProduct.get(line.ref_id) ?? 0) + line.qty);
+  }
+  return [...byProduct].map(([product_id, qty]) => ({ product_id, qty }));
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,5 +1,7 @@
 import { createApp, createRoute, z } from "@clawnify/app";
 import { query, get, run } from "./db.js";
+import { CheckoutError, round2 } from "./checkout.js";
+import { recordSale, readSale, staffTakings, dailyTakings } from "./sales.js";
 
 type Env = { Bindings: { DB: D1Database } };
 
@@ -1006,6 +1008,239 @@ app.openapi(deleteProduct, async (c) => {
   const { id } = c.req.valid("param");
   await run("DELETE FROM products WHERE id = ?", [id]);
   return c.json({ ok: true }, 200);
+});
+
+
+// ── Checkout / till ────────────────────────────────────────────────
+//
+// `appointments.total_price` is what was quoted at booking. A sale is what was
+// actually taken. Keeping both is the point: the gap between them — discounts
+// given, tips earned, retail added at the desk — is what the staff report is
+// made of.
+
+const SaleItemInputSchema = z.object({
+  kind: z.enum(["service", "product"]),
+  ref_id: z.number().int().nullable().optional(),
+  name: z.string(),
+  unit_price: z.number(),
+  qty: z.number().int(),
+});
+
+const AdjustmentSchema = z.object({
+  kind: z.enum(["percent", "amount"]),
+  value: z.number(),
+});
+
+const SaleItemSchema = z.object({
+  id: z.number().int(),
+  sale_id: z.string(),
+  line_no: z.number().int(),
+  kind: z.string(),
+  ref_id: z.number().int().nullable(),
+  name: z.string(),
+  unit_price: z.number(),
+  qty: z.number().int(),
+  line_total: z.number(),
+}).openapi("SaleItem");
+
+const SaleSchema = z.object({
+  id: z.string(),
+  status: z.string(),
+  appointment_id: z.number().int().nullable(),
+  client_id: z.number().int().nullable(),
+  staff_id: z.number().int().nullable(),
+  subtotal: z.number(),
+  discount: z.number(),
+  tip: z.number(),
+  total: z.number(),
+  payment_method: z.string(),
+  note: z.string(),
+  created_at: z.string(),
+  closed_at: z.string().nullable(),
+  client_name: z.string().nullable().optional(),
+  staff_name: z.string().nullable().optional(),
+  appointment_identifier: z.string().nullable().optional(),
+  items: z.array(SaleItemSchema).optional(),
+}).openapi("Sale");
+
+// Ring up a ticket.
+//
+// `id` is a UUID minted by the caller and is the idempotency key: posting the
+// same one twice returns the original receipt rather than charging again.
+// Totals are computed server-side from the lines — the caller sends intent
+// ("20% tip"), never the total.
+const createSale = createRoute({
+  method: "post",
+  path: "/api/sales",
+  request: {
+    body: { content: { "application/json": { schema: z.object({
+      id: z.string().openapi({ description: "Caller-minted UUID; also the idempotency key" }),
+      appointment_id: z.number().int().nullable().optional(),
+      client_id: z.number().int().nullable().optional(),
+      staff_id: z.number().int().nullable().optional(),
+      items: z.array(SaleItemInputSchema),
+      discount: AdjustmentSchema.optional(),
+      tip: AdjustmentSchema.optional(),
+      payment_method: z.enum(["cash", "card", "other"]),
+      note: z.string().optional(),
+    }) } } },
+  },
+  responses: {
+    201: { description: "Sale recorded", content: { "application/json": { schema: z.object({ sale: SaleSchema }) } } },
+    400: { description: "Rejected", content: { "application/json": { schema: ErrorSchema } } },
+  },
+});
+
+app.openapi(createSale, async (c) => {
+  const body = c.req.valid("json");
+  try {
+    const sale = await recordSale(body);
+    return c.json({ sale }, 201);
+  } catch (err) {
+    // A CheckoutError is the caller's fault (bad line, impossible discount),
+    // so it comes back as a 400 with the reason. Anything else is ours.
+    if (err instanceof CheckoutError) {
+      return c.json({ error: err.message }, 400);
+    }
+    throw err;
+  }
+});
+
+// One receipt, itemised. Answers "what exactly did this client pay for?"
+// without piecing transactions together by hand.
+const getSale = createRoute({
+  method: "get",
+  path: "/api/sales/{id}",
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    200: { description: "Sale", content: { "application/json": { schema: z.object({ sale: SaleSchema }) } } },
+    404: { description: "Not found", content: { "application/json": { schema: ErrorSchema } } },
+  },
+});
+
+app.openapi(getSale, async (c) => {
+  const { id } = c.req.valid("param");
+  const sale = await readSale(id);
+  if (!sale) return c.json({ error: "Sale not found" }, 404);
+  return c.json({ sale }, 200);
+});
+
+const listSales = createRoute({
+  method: "get",
+  path: "/api/sales",
+  request: {
+    query: z.object({
+      from: z.string().optional().openapi({ description: "YYYY-MM-DD, inclusive" }),
+      to: z.string().optional().openapi({ description: "YYYY-MM-DD, inclusive" }),
+      staff_id: z.string().optional(),
+      client_id: z.string().optional(),
+      limit: z.string().optional(),
+    }),
+  },
+  responses: {
+    200: { description: "Sales", content: { "application/json": { schema: z.object({ sales: z.array(SaleSchema) }) } } },
+  },
+});
+
+app.openapi(listSales, async (c) => {
+  const q = c.req.valid("query");
+  // Closed sales only. An open row is a checkout that never finished and is
+  // not money that was taken.
+  let where = "WHERE sa.status = 'closed'";
+  const params: unknown[] = [];
+  if (q.from) { where += " AND date(sa.closed_at) >= ?"; params.push(q.from); }
+  if (q.to) { where += " AND date(sa.closed_at) <= ?"; params.push(q.to); }
+  if (q.staff_id) { where += " AND sa.staff_id = ?"; params.push(Number(q.staff_id)); }
+  if (q.client_id) { where += " AND sa.client_id = ?"; params.push(Number(q.client_id)); }
+  const limit = Math.min(Math.max(Number(q.limit) || 100, 1), 500);
+
+  const sales = await query(
+    `SELECT sa.*, cl.name AS client_name, st.name AS staff_name,
+            a.identifier AS appointment_identifier
+     FROM sales sa
+     LEFT JOIN clients cl ON cl.id = sa.client_id
+     LEFT JOIN staff st ON st.id = sa.staff_id
+     LEFT JOIN appointments a ON a.id = sa.appointment_id
+     ${where}
+     ORDER BY sa.closed_at DESC
+     LIMIT ?`,
+    [...params, limit],
+  );
+  return c.json({ sales }, 200);
+});
+
+// Takings, split per staff member and per day. This is the report the
+// "staff targets" question is really asking for: what each person actually
+// brought in, separated into service work, retail and tips.
+const takingsReport = createRoute({
+  method: "get",
+  path: "/api/reports/takings",
+  request: {
+    query: z.object({
+      from: z.string().optional().openapi({ description: "YYYY-MM-DD, defaults to the 1st of this month" }),
+      to: z.string().optional().openapi({ description: "YYYY-MM-DD, defaults to today" }),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Takings",
+      content: { "application/json": { schema: z.object({
+        from: z.string(),
+        to: z.string(),
+        totals: z.object({
+          sale_count: z.number().int(),
+          service_revenue: z.number(),
+          retail_revenue: z.number(),
+          discount: z.number(),
+          tips: z.number(),
+          total: z.number(),
+        }),
+        staff: z.array(z.object({
+          staff_id: z.number().int().nullable(),
+          staff_name: z.string(),
+          staff_color: z.string(),
+          sale_count: z.number().int(),
+          service_revenue: z.number(),
+          retail_revenue: z.number(),
+          discount: z.number(),
+          tips: z.number(),
+          total: z.number(),
+        })),
+        days: z.array(z.object({
+          date: z.string(),
+          sale_count: z.number().int(),
+          subtotal: z.number(),
+          discount: z.number(),
+          tips: z.number(),
+          total: z.number(),
+        })),
+      }) } },
+    },
+  },
+});
+
+app.openapi(takingsReport, async (c) => {
+  const q = c.req.valid("query");
+  const today = new Date().toISOString().split("T")[0];
+  const to = q.to || today;
+  const from = q.from || `${today.slice(0, 7)}-01`;
+
+  const staff = await staffTakings(from, to);
+  const days = await dailyTakings(from, to);
+
+  const totals = staff.reduce(
+    (acc, row) => ({
+      sale_count: acc.sale_count + row.sale_count,
+      service_revenue: round2(acc.service_revenue + row.service_revenue),
+      retail_revenue: round2(acc.retail_revenue + row.retail_revenue),
+      discount: round2(acc.discount + row.discount),
+      tips: round2(acc.tips + row.tips),
+      total: round2(acc.total + row.total),
+    }),
+    { sale_count: 0, service_revenue: 0, retail_revenue: 0, discount: 0, tips: 0, total: 0 },
+  );
+
+  return c.json({ from, to, totals, staff, days }, 200);
 });
 
 export default app;

--- a/src/server/sales.ts
+++ b/src/server/sales.ts
@@ -1,0 +1,257 @@
+// Recording and reporting the till.
+//
+// The write order in `recordSale` is not stylistic — it is the only safe order
+// available here. There is no transaction: the app's database surface
+// (`query` / `get` / `run` from @clawnify/db) is one statement per call, with
+// no multi-statement batching on either supported storage backend. Foreign
+// keys are enforced, so a child row cannot be written before its parent.
+//
+// So the sale is written parent-first as `status='open'`, then its lines, and
+// the flip to `'closed'` is the commit point. Reports only ever count closed
+// sales, which means a write that dies half way through leaves something
+// invisible rather than something wrong.
+
+import { query, get, run } from "./db.js";
+import { priceSale, stockDraw, type SaleInput, type PaymentMethod } from "./checkout.js";
+
+export interface RecordSaleInput extends SaleInput {
+  /** Caller-supplied UUID. Doubles as the idempotency key. */
+  id: string;
+  appointment_id?: number | null;
+  client_id?: number | null;
+  staff_id?: number | null;
+  note?: string;
+}
+
+export interface SaleRow {
+  id: string;
+  status: string;
+  appointment_id: number | null;
+  client_id: number | null;
+  staff_id: number | null;
+  subtotal: number;
+  discount: number;
+  tip: number;
+  total: number;
+  payment_method: PaymentMethod;
+  note: string;
+  created_at: string;
+  closed_at: string | null;
+  client_name?: string | null;
+  staff_name?: string | null;
+  appointment_identifier?: string | null;
+  items?: unknown[];
+}
+
+/** The receipt: one sale, its lines, and the names behind its ids. */
+export async function readSale(id: string): Promise<SaleRow | undefined> {
+  const sale = await get<SaleRow>(
+    `SELECT sa.*, cl.name AS client_name, st.name AS staff_name,
+            a.identifier AS appointment_identifier
+     FROM sales sa
+     LEFT JOIN clients cl ON cl.id = sa.client_id
+     LEFT JOIN staff st ON st.id = sa.staff_id
+     LEFT JOIN appointments a ON a.id = sa.appointment_id
+     WHERE sa.id = ?`,
+    [id],
+  );
+  if (!sale) return undefined;
+  sale.items = await query(
+    "SELECT * FROM sale_items WHERE sale_id = ? ORDER BY line_no",
+    [id],
+  );
+  return sale;
+}
+
+/**
+ * Rings up a ticket. Safe to call twice with the same `id` — a completed sale
+ * is handed straight back rather than charged again.
+ */
+export async function recordSale(input: RecordSaleInput): Promise<SaleRow> {
+  const id = (input.id ?? "").trim();
+  if (!id) throw new Error("a sale needs an id");
+
+  const existing = await get<{ status: string }>("SELECT status FROM sales WHERE id = ?", [id]);
+  if (existing?.status === "closed") {
+    // Already rung up. The client is retrying a request that in fact
+    // succeeded, so give it the receipt instead of taking the money twice.
+    return (await readSale(id))!;
+  }
+
+  // Prices the ticket server-side. The browser sends intent ("20% tip"); the
+  // total is decided here, so a stale or tampered client cannot set it.
+  const priced = priceSale(input);
+
+  // 1. Header, open. Counted by nothing until step 4.
+  await run(
+    `INSERT OR IGNORE INTO sales
+       (id, status, appointment_id, client_id, staff_id,
+        subtotal, discount, tip, total, payment_method, note)
+     VALUES (?, 'open', ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      id, input.appointment_id ?? null, input.client_id ?? null, input.staff_id ?? null,
+      priced.subtotal, priced.discount, priced.tip, priced.total,
+      input.payment_method, input.note ?? "",
+    ],
+  );
+  // Resuming an abandoned open sale: bring the header in line with this
+  // attempt. Guarded on status so a closed sale can never be re-priced.
+  await run(
+    `UPDATE sales SET appointment_id = ?, client_id = ?, staff_id = ?,
+            subtotal = ?, discount = ?, tip = ?, total = ?, payment_method = ?, note = ?
+     WHERE id = ? AND status = 'open'`,
+    [
+      input.appointment_id ?? null, input.client_id ?? null, input.staff_id ?? null,
+      priced.subtotal, priced.discount, priced.tip, priced.total,
+      input.payment_method, input.note ?? "", id,
+    ],
+  );
+
+  // 2. Lines, rewritten wholesale. Safe because an open sale counts for
+  //    nothing, so there is no partial state to preserve.
+  await run("DELETE FROM sale_items WHERE sale_id = ?", [id]);
+  for (const [i, line] of priced.lines.entries()) {
+    await run(
+      `INSERT OR IGNORE INTO sale_items
+         (sale_id, line_no, kind, ref_id, name, unit_price, qty, line_total)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      [id, i, line.kind, line.ref_id ?? null, line.name, line.unit_price, line.qty, line.line_total],
+    );
+  }
+
+  // 3. Stock. The movement row is the guard, not a log: its primary key is
+  //    (sale_id, product_id), so it can be written at most once per sale, and
+  //    the decrement runs only on the attempt that wrote it. That is what
+  //    makes an untransacted `stock = stock - ?` safe to retry.
+  //
+  //    shortcut: if the process dies between the movement row and the
+  //    decrement, on-hand is left one draw high. Reconcile from
+  //    stock_movements; revisit if a real cash-drawer audit ever needs to be
+  //    exact to the unit.
+  for (const draw of stockDraw(priced.lines)) {
+    const movement = await run(
+      "INSERT OR IGNORE INTO stock_movements (sale_id, product_id, qty) VALUES (?, ?, ?)",
+      [id, draw.product_id, draw.qty],
+    );
+    if (movement.changes > 0) {
+      await run(
+        "UPDATE products SET stock = stock - ?, updated_at = datetime('now') WHERE id = ?",
+        [draw.qty, draw.product_id],
+      );
+    }
+  }
+
+  // 4. Commit.
+  await run(
+    "UPDATE sales SET status = 'closed', closed_at = datetime('now') WHERE id = ? AND status = 'open'",
+    [id],
+  );
+
+  // A paid-up appointment is a finished one.
+  if (input.appointment_id) {
+    await run(
+      "UPDATE appointments SET status = 'completed', updated_at = datetime('now') WHERE id = ? AND status != 'cancelled'",
+      [input.appointment_id],
+    );
+  }
+
+  return (await readSale(id))!;
+}
+
+export interface StaffTakings {
+  staff_id: number | null;
+  staff_name: string;
+  staff_color: string;
+  sale_count: number;
+  service_revenue: number;
+  retail_revenue: number;
+  discount: number;
+  tips: number;
+  total: number;
+}
+
+/**
+ * Takings per staff member over a date range.
+ *
+ * Deliberately two queries. Joining `sale_items` to `sales` to get both the
+ * line split and the tip in one pass multiplies the tip by the number of
+ * lines on the ticket — a three-line sale would report triple tips. The
+ * sale-level figures and the line-level figures are aggregated separately and
+ * stitched together here.
+ */
+export async function staffTakings(from: string, to: string): Promise<StaffTakings[]> {
+  const perSale = await query<{
+    staff_id: number | null; staff_name: string | null; staff_color: string | null;
+    sale_count: number; discount: number; tips: number; total: number;
+  }>(
+    `SELECT sa.staff_id,
+            st.name AS staff_name,
+            st.color AS staff_color,
+            COUNT(*) AS sale_count,
+            COALESCE(SUM(sa.discount), 0) AS discount,
+            COALESCE(SUM(sa.tip), 0) AS tips,
+            COALESCE(SUM(sa.total), 0) AS total
+     FROM sales sa
+     LEFT JOIN staff st ON st.id = sa.staff_id
+     WHERE sa.status = 'closed' AND date(sa.closed_at) BETWEEN ? AND ?
+     GROUP BY sa.staff_id`,
+    [from, to],
+  );
+
+  const perLine = await query<{ staff_id: number | null; kind: string; revenue: number }>(
+    `SELECT sa.staff_id, si.kind, COALESCE(SUM(si.line_total), 0) AS revenue
+     FROM sales sa
+     JOIN sale_items si ON si.sale_id = sa.id
+     WHERE sa.status = 'closed' AND date(sa.closed_at) BETWEEN ? AND ?
+     GROUP BY sa.staff_id, si.kind`,
+    [from, to],
+  );
+
+  const lineIndex = new Map<string, number>();
+  for (const row of perLine) {
+    lineIndex.set(`${row.staff_id ?? "none"}:${row.kind}`, row.revenue);
+  }
+
+  return perSale
+    .map((row) => {
+      const key = row.staff_id ?? "none";
+      return {
+        staff_id: row.staff_id,
+        staff_name: row.staff_name ?? "Unassigned",
+        staff_color: row.staff_color ?? "#6b7280",
+        sale_count: row.sale_count,
+        service_revenue: lineIndex.get(`${key}:service`) ?? 0,
+        retail_revenue: lineIndex.get(`${key}:product`) ?? 0,
+        discount: row.discount,
+        tips: row.tips,
+        total: row.total,
+      };
+    })
+    .sort((a, b) => b.total - a.total);
+}
+
+export interface DayTakings {
+  date: string;
+  sale_count: number;
+  subtotal: number;
+  discount: number;
+  tips: number;
+  total: number;
+}
+
+/** Takings per day over a date range, most recent first. */
+export async function dailyTakings(from: string, to: string): Promise<DayTakings[]> {
+  return query<DayTakings>(
+    `SELECT date(closed_at) AS date,
+            COUNT(*) AS sale_count,
+            COALESCE(SUM(subtotal), 0) AS subtotal,
+            COALESCE(SUM(discount), 0) AS discount,
+            COALESCE(SUM(tip), 0) AS tips,
+            COALESCE(SUM(total), 0) AS total
+     FROM sales
+     WHERE status = 'closed' AND date(closed_at) BETWEEN ? AND ?
+     GROUP BY date(closed_at)
+     ORDER BY date(closed_at) DESC`,
+    [from, to],
+  );
+}

--- a/src/server/schema.sql
+++ b/src/server/schema.sql
@@ -149,3 +149,82 @@ CREATE INDEX IF NOT EXISTS idx_blocked_slots_date ON blocked_slots(blocked_date)
 CREATE INDEX IF NOT EXISTS idx_clients_name ON clients(name);
 CREATE INDEX IF NOT EXISTS idx_products_category ON products(category);
 CREATE INDEX IF NOT EXISTS idx_services_category ON services(category);
+
+-- ── Checkout / till ────────────────────────────────────────────────────
+--
+-- A sale is the money record: what was actually taken, as opposed to
+-- `appointments.total_price`, which is what was quoted when the booking was
+-- made. Keeping them separate is the whole point — the gap between booked and
+-- taken (discounts given, tips earned, retail added at the desk) is what the
+-- staff report is made of, and overwriting the quote would destroy it.
+--
+-- `appointment_id` is nullable on purpose: a walk-in buying shampoo is a sale
+-- with no appointment. Square models this the same way — its Order object
+-- carries no booking reference at all.
+--
+-- WRITE ORDER MATTERS. There is no transaction available here: the app's db
+-- surface (@clawnify/db query/get/run) is one statement per call, with no
+-- multi-statement batching on either supported storage backend. Foreign keys
+-- are enforced, so children cannot be written before their parent. The sale
+-- is therefore written header-first as
+-- status='open', then its items, and the final flip to 'closed' is the commit
+-- point. Reports count 'closed' only, so a half-written sale is invisible
+-- rather than wrong, and replaying the same sale id completes it instead of
+-- duplicating it.
+CREATE TABLE IF NOT EXISTS sales (
+  -- Caller-supplied UUID. This is the idempotency key: retrying a checkout
+  -- with the same id resumes it rather than ringing it up twice.
+  id TEXT PRIMARY KEY,
+  status TEXT NOT NULL DEFAULT 'open',
+  appointment_id INTEGER REFERENCES appointments(id) ON DELETE SET NULL,
+  client_id INTEGER REFERENCES clients(id) ON DELETE SET NULL,
+  staff_id INTEGER REFERENCES staff(id) ON DELETE SET NULL,
+  -- Money is REAL to match `services.price` / `appointments.total_price`.
+  -- Integer cents would be more correct; two money conventions in one app
+  -- would be worse. Totals are rounded to 2dp as they are computed.
+  subtotal REAL NOT NULL DEFAULT 0,
+  discount REAL NOT NULL DEFAULT 0,
+  tip REAL NOT NULL DEFAULT 0,
+  total REAL NOT NULL DEFAULT 0,
+  payment_method TEXT NOT NULL DEFAULT 'cash',
+  note TEXT DEFAULT '',
+  created_at TEXT DEFAULT (datetime('now')),
+  closed_at TEXT
+);
+
+-- One row per line on the ticket. `name` and `unit_price` are snapshots: a
+-- closed sale must keep reading the same way after someone edits the service
+-- catalogue or a product price.
+CREATE TABLE IF NOT EXISTS sale_items (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  sale_id TEXT NOT NULL REFERENCES sales(id) ON DELETE CASCADE,
+  -- Position on the ticket. Paired with sale_id this makes writing a line
+  -- idempotent (INSERT OR IGNORE) while still allowing the same product to
+  -- appear twice, which is a normal thing for a front desk to do.
+  line_no INTEGER NOT NULL,
+  kind TEXT NOT NULL,                -- 'service' | 'product'
+  ref_id INTEGER,                    -- services.id or products.id, if it still exists
+  name TEXT NOT NULL,
+  unit_price REAL NOT NULL DEFAULT 0,
+  qty INTEGER NOT NULL DEFAULT 1,
+  line_total REAL NOT NULL DEFAULT 0,
+  UNIQUE (sale_id, line_no)
+);
+
+-- Why this table exists: `UPDATE products SET stock = stock - ?` is not
+-- idempotent, and without a transaction a retried checkout would decrement
+-- twice. This row is the guard — INSERT OR IGNORE on (sale_id, product_id)
+-- succeeds exactly once per sale, and the stock decrement is applied only
+-- when it does. It doubles as the audit trail for reconciling on-hand counts.
+CREATE TABLE IF NOT EXISTS stock_movements (
+  sale_id TEXT NOT NULL REFERENCES sales(id) ON DELETE CASCADE,
+  product_id INTEGER NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+  qty INTEGER NOT NULL,
+  created_at TEXT DEFAULT (datetime('now')),
+  PRIMARY KEY (sale_id, product_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_sales_status_closed ON sales(status, closed_at);
+CREATE INDEX IF NOT EXISTS idx_sales_staff ON sales(staff_id);
+CREATE INDEX IF NOT EXISTS idx_sales_appointment ON sales(appointment_id);
+CREATE INDEX IF NOT EXISTS idx_sale_items_sale ON sale_items(sale_id);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
**Draft — persistence blockers found during final review.** Real-route SQLite fault injection reproduces three failures:

- Interrupt after inserting `stock_movements` but before decrementing `products.stock`: retry closes the sale, while stock remains 25 instead of 24.
- Interrupt before closing a one-unit sale, then retry the same ID with quantity 5: the receipt records five units ($124.95), while inventory and the movement still account for one.
- Submit two fresh sale IDs for the same appointment: both close, recording $100 for the same $50 visit.

Before merging, make sale lines, inventory effects, and completion recover consistently; define immutable retry payloads; prevent a fresh checkout dialog from ringing up the same appointment again. Add route-level interruption/retry regressions. This branch also conflicts with main's DDL-only schema/seed changes.

---

Appointments recorded what was **quoted**. Nothing recorded what was **taken** — so tips had nowhere to live, retail products could never actually be sold (`products.stock` never moved), and the dashboard's "revenue" was just the sum of booked prices.

This adds the missing till.

## What it does

Closes an appointment — or a walk-in with no appointment at all — onto an itemised ticket: booked services, retail products added at the desk, a percentage or flat discount, preset (15/18/20%) or custom tips, and a payment method. Then reports on it.

- **`/reports`** — takings per staff member and per day, split into service revenue, retail, discounts and tips, with a footer aggregate.
- **`GET /api/sales/:id`** — a full line-by-line receipt for one visit.
- Retail sales now draw down inventory, recorded in a `stock_movements` audit trail.

## Design notes

**A sale is not an appointment.** It gets its own tables (`sales`, `sale_items`, `stock_movements`) with prices snapshotted at the time of sale. `appointments.total_price` stays the quoted figure, so the booked-vs-taken gap survives — that gap is what the staff report is made of. `sales.appointment_id` is nullable so a walk-in buying shampoo is a first-class sale.

**Money is priced server-side, in integer cents.** The client sends intent (`{ tip: { kind: "percent", value: 20 } }`) and never the total, so a stale or tampered browser cannot dictate what is charged. A percentage tip is taken on the post-discount figure. The arithmetic lives in one dependency-free module that both the server and the checkout preview import, so the figure on screen cannot disagree with the figure charged. 23 unit tests cover the arithmetic, the rounding, and the trust-boundary rejections.

**There is no multi-statement transaction available**, and foreign keys are enforced, so children can't be written before their parent. The sale is written header-first as `status='open'`, then its lines, and the flip to `'closed'` is the commit point. Reports count closed sales only, so a write that dies half way through leaves something invisible rather than something wrong. The caller-minted sale `id` is the idempotency key — posting the same sale twice returns the original receipt instead of charging again — and `stock_movements` is keyed `(sale_id, product_id)` so a retried checkout can never draw stock twice.

**Tips are aggregated separately from line items** in the report. Joining `sale_items` to `sales` in one pass multiplies the tip by the number of lines on the ticket; a three-line sale would report triple tips.

## Verified

Against a real local database, not just a passing build:

- `94.99 − 10% + 20% tip = 102.59` end to end through the API and again through the UI.
- Replaying the same sale id returned the original receipt and left stock **unchanged** (no double-decrement, one `stock_movements` row).
- The same product on two ticket lines kept both lines but wrote one movement of the summed quantity; stock moved `40 → 35`.
- A discount larger than the subtotal was rejected `400` with no orphan sale row.
- Checking out flipped the appointment to `completed` while its booked `$70` stayed put against a recorded sale of `$113.99`.
- Report totals reconcile: services + retail − discounts + tips == total.
- 23/23 unit tests, clean production build, no new TypeScript errors in any new file.

## Not in scope

No card processing, memberships, gift cards, packages or commission rules. One shortcut is marked inline with its ceiling: if the process dies between writing a stock movement and applying the decrement, on-hand is left one draw high, reconcilable from `stock_movements`.

