### PR TITLE
Keep calendar dates on the local calendar, not UTC

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "wrangler d1 execute open-salon-db --local --file=src/server/schema.sql && concurrently -n ui,api -c cyan,green \"vite\" \"wrangler dev --port 8787\"",
-    "build": "vite build"
+    "build": "vite build",
+    "test": "node --experimental-strip-types --test 'src/**/*.test.ts'"
   },
   "dependencies": {
     "@clawnify/app": "^0.1.0",

--- a/src/client/components/calendar-view.tsx
+++ b/src/client/components/calendar-view.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { CreateAppointment } from "./create-appointment";
 import { cn } from "@/lib/utils";
+import { parseDate, shiftDate, today } from "@/lib/dates";
 
 const HOURS = Array.from({ length: 14 }, (_, i) => i + 7); // 7 AM to 8 PM
 
@@ -34,14 +35,10 @@ export function CalendarView() {
   const [blockEnd, setBlockEnd] = useState("13:00");
   const [blockReason, setBlockReason] = useState("");
 
-  const dateObj = new Date(calendarDate + "T00:00:00");
-  const todayStr = new Date().toISOString().split("T")[0];
+  const dateObj = parseDate(calendarDate);
+  const todayStr = today();
 
-  const shiftDay = (delta: number) => {
-    const d = new Date(calendarDate + "T00:00:00");
-    d.setDate(d.getDate() + delta);
-    setCalendarDate(d.toISOString().split("T")[0]);
-  };
+  const shiftDay = (delta: number) => setCalendarDate(shiftDate(calendarDate, delta));
 
   const dayStart = HOURS[0] * 60;
   const dayEnd = (HOURS[HOURS.length - 1] + 1) * 60;

--- a/src/client/components/create-appointment.tsx
+++ b/src/client/components/create-appointment.tsx
@@ -7,6 +7,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
+import { today } from "@/lib/dates";
 
 interface Props {
   onClose: () => void;
@@ -17,7 +18,7 @@ export function CreateAppointment({ onClose, defaultDate }: Props) {
   const { addAppointment, clientLookup, staffLookup, services, setError } = useApp();
   const [clientId, setClientId] = useState("");
   const [staffId, setStaffId] = useState("");
-  const [date, setDate] = useState(defaultDate || new Date().toISOString().split("T")[0]);
+  const [date, setDate] = useState(defaultDate || today());
   const [startTime, setStartTime] = useState("09:00");
   const [selectedServices, setSelectedServices] = useState<number[]>([]);
   const [notes, setNotes] = useState("");

--- a/src/client/components/dashboard.tsx
+++ b/src/client/components/dashboard.tsx
@@ -3,11 +3,12 @@ import { CalendarDays, Users, Clock, DollarSign, Package, AlertTriangle } from "
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { today } from "@/lib/dates";
 
 export function Dashboard() {
   const { stats, navigate, calendarAppointments } = useApp();
 
-  const todayStr = new Date().toISOString().split("T")[0];
+  const todayStr = today();
   const todayAppointments = calendarAppointments
     .filter((a) => a.scheduled_date === todayStr)
     .sort((a, b) => a.start_time.localeCompare(b.start_time));

--- a/src/client/hooks/use-app.ts
+++ b/src/client/hooks/use-app.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect } from "preact/hooks";
 import { api } from "../api";
+import { today } from "../lib/dates";
 import type {
   Appointment, Client, Staff, Service, Product, BlockedSlot, Stats, PaginatedState,
   ClientLookup, StaffLookup,
@@ -19,7 +20,7 @@ export function useAppState(isAgent: boolean, navigate: (to: string) => void): A
   const [selectedAppointment, setSelectedAppointment] = useState<Appointment | null>(null);
 
   // Calendar
-  const todayStr = new Date().toISOString().split("T")[0];
+  const todayStr = today();
   const [calendarDate, setCalendarDate] = useState(todayStr);
   const [calendarAppointments, setCalendarAppointments] = useState<Appointment[]>([]);
   const [calendarBlocked, setCalendarBlocked] = useState<BlockedSlot[]>([]);

--- a/src/client/lib/dates.test.ts
+++ b/src/client/lib/dates.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { formatDate, parseDate, shiftDate, today } from "./dates.ts";
+
+/** Run `fn` as if the browser were in `zone`. Node re-reads TZ per call. */
+function inZone(zone: string, fn: () => void) {
+  const previous = process.env.TZ;
+  process.env.TZ = zone;
+  try {
+    fn();
+  } finally {
+    process.env.TZ = previous;
+  }
+}
+
+const AHEAD_OF_UTC = ["Europe/Rome", "Australia/Sydney", "Asia/Kolkata"];
+const BEHIND_UTC = ["America/New_York", "America/Los_Angeles"];
+
+test("shiftDate moves a day in every zone", () => {
+  for (const zone of [...AHEAD_OF_UTC, ...BEHIND_UTC, "UTC"]) {
+    inZone(zone, () => {
+      // The regression in issue #5: this returned "2026-08-29" east of UTC,
+      // so the calendar's next-day button silently did nothing.
+      assert.equal(shiftDate("2026-08-29", 1), "2026-08-30", zone);
+      assert.equal(shiftDate("2026-08-29", -1), "2026-08-28", zone);
+    });
+  }
+});
+
+test("shiftDate crosses month, year and leap-day boundaries", () => {
+  assert.equal(shiftDate("2026-08-31", 1), "2026-09-01");
+  assert.equal(shiftDate("2026-01-01", -1), "2025-12-31");
+  assert.equal(shiftDate("2028-02-28", 1), "2028-02-29");
+});
+
+test("today() is the user's local day, not the UTC day", () => {
+  // 21:30 in New York is already tomorrow in UTC. A salon is still open.
+  inZone("America/New_York", () => {
+    assert.equal(today(new Date("2026-09-04T01:30:00Z")), "2026-09-03");
+  });
+  // 01:30 in Rome is still yesterday in UTC.
+  inZone("Europe/Rome", () => {
+    assert.equal(today(new Date("2026-09-03T23:30:00Z")), "2026-09-04");
+  });
+});
+
+test("shiftDate survives zones that change the clock at midnight", () => {
+  // Santiago springs forward at 00:00, so local midnight does not exist that
+  // night; a midnight-anchored implementation slips a day here.
+  inZone("America/Santiago", () => {
+    assert.equal(shiftDate("2026-09-05", 1), "2026-09-06");
+    assert.equal(shiftDate("2026-09-06", -1), "2026-09-05");
+  });
+});
+
+test("parseDate round-trips through formatDate", () => {
+  for (const zone of [...AHEAD_OF_UTC, ...BEHIND_UTC]) {
+    inZone(zone, () => {
+      assert.equal(formatDate(parseDate("2026-08-29")), "2026-08-29", zone);
+    });
+  }
+});

--- a/src/client/lib/dates.ts
+++ b/src/client/lib/dates.ts
@@ -1,0 +1,42 @@
+/**
+ * Local calendar-date helpers.
+ *
+ * Dates in this app are bare `YYYY-MM-DD` strings meaning "a day at the salon" —
+ * no time, no zone. `Date#toISOString()` formats the *UTC* instant, so building
+ * one of these strings from it shifts the day for anyone whose local date
+ * differs from the UTC date, which is most of the world for part of every day.
+ * Everything here stays on the local calendar instead.
+ */
+
+const pad = (n: number) => String(n).padStart(2, "0");
+
+/** `YYYY-MM-DD` for a Date, read off its local calendar fields. */
+export function formatDate(d: Date): string {
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+/** The day the user is currently living in, as `YYYY-MM-DD`. */
+export function today(now: Date = new Date()): string {
+  return formatDate(now);
+}
+
+/**
+ * Parse `YYYY-MM-DD` into a local Date.
+ *
+ * Anchored at noon rather than midnight. A few zones move the clock at 00:00
+ * (Santiago, Havana), so on those nights local midnight is a time that does not
+ * exist and the Date silently lands on 01:00. Day arithmetic still works from
+ * there, but it leaves an hour of margin against a boundary instead of twelve;
+ * noon costs nothing and keeps every case far away from one.
+ */
+export function parseDate(date: string): Date {
+  const [y, m, d] = date.split("-").map(Number);
+  return new Date(y, m - 1, d, 12);
+}
+
+/** Move a `YYYY-MM-DD` by whole days, staying on the local calendar. */
+export function shiftDate(date: string, days: number): string {
+  const d = parseDate(date);
+  d.setDate(d.getDate() + days);
+  return formatDate(d);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
Fixes #5.

## What was wrong

Dates in this app are bare `YYYY-MM-DD` strings that mean *a day at the salon* — no time, no zone. They were being built with `Date#toISOString()`, which formats the **UTC** instant. That shifts the day for anyone whose local date differs from the UTC date, which is most of the world for part of every day.

Two separate consequences. The issue reports the first; the second is the one that costs money.

**1. Next/previous day did nothing east of UTC (the reported bug).**
`shiftDay` parsed `calendarDate + "T00:00:00"` as *local* midnight, then formatted it back with `toISOString()` as *UTC*. In UTC+2, local midnight on Aug 30 is `2026-08-29T22:00Z`, so the date string came back unchanged and the button silently no-oped. Reproduces in Rome and Sydney; does not reproduce in New York, which is why it can survive review.

**2. "Today" was the UTC day, in four places — including the new-booking form's default date.**
`new Date().toISOString().split("T")[0]` appeared in `calendar-view.tsx`, `dashboard.tsx`, `use-app.ts` and `create-appointment.tsx`. Measured:

| Local time | App's "today" | Actual local day | |
|---|---|---|---|
| 21:30 New York | 2026-09-04 | 2026-09-03 | wrong day |
| 01:30 Rome | 2026-09-03 | 2026-09-04 | wrong day |

Both are hours a salon is open. A walk-in booked at 21:30 in New York was silently written to **tomorrow's** date, because the form's date field defaulted to it. That is a data-correctness bug in the app's core object, not a UI nit — and it's invisible, because the calendar reading the same wrong "today" agreed with the form.

## The fix

New `src/client/lib/dates.ts` — `today()`, `formatDate()`, `parseDate()`, `shiftDate()` — which stays on local calendar fields throughout and never round-trips through UTC. The four call sites now use it. `shiftDay` collapses to a one-liner.

`parseDate` anchors at noon rather than midnight: a few zones (Santiago, Havana) move the clock at 00:00, so on those nights local midnight does not exist and the `Date` lands on 01:00. Day arithmetic still works from there, but noon costs nothing and keeps every case twelve hours from a boundary instead of one.

## Verification

- `npm test` (new): 5 tests sweeping zones either side of UTC and over month, year, leap-day and DST boundaries. **Three of the five fail against the old implementation** — checked by swapping it back in, so they genuinely pin the bug rather than the fix.
- Ran the app in a real UTC+2 browser (`Europe/Amsterdam`, the zone from the report): next-day, previous-day and Today all step correctly. Before this change the next-day button did nothing there.
- `tsc --noEmit`: 177 errors before, 177 after. Diffed the error sets against `origin/main` — identical modulo line-number drift from the added import. (`main` is red already; these are pre-existing implicit-`any` handlers.)
- `npm run build` passes.

## Deliberately not in scope

- **`src/server/index.ts`'s own `today`** has the same shape, but a Worker has no user timezone to read — fixing it properly needs a salon timezone setting rather than a local-time helper. It only bounds an "upcoming" count, so the blast radius is one number, not a booking. Worth doing alongside whatever introduces business hours.
- The 177 pre-existing typecheck errors.

## Note for whoever merges the public-booking work

This adds `"test"` to `package.json` and excludes `src/**/*.test.ts` in `tsconfig.json`. The in-flight booking branch makes the same two changes with a narrower test glob (`src/server/*.test.ts`); this one's `'src/**/*.test.ts'` is a superset and covers both, so take this side of that conflict.
