### PR TITLE
Stop the app silently double-booking a staff member

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "wrangler d1 execute open-salon-db --local --file=src/server/schema.sql && concurrently -n ui,api -c cyan,green \"vite\" \"wrangler dev --port 8787\"",
-    "build": "vite build"
+    "build": "vite build",
+    "test": "node --experimental-strip-types --test 'src/**/*.test.ts'"
   },
   "dependencies": {
     "@clawnify/app": "^0.1.0",

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -1,3 +1,11 @@
+/** A request the server refused, with the status and body so callers can react to the reason. */
+export class ApiError extends Error {
+  constructor(message: string, readonly status: number, readonly body: unknown) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
 export async function api<T>(method: string, path: string, body?: unknown): Promise<T> {
   const opts: RequestInit = { method, headers: {} };
   if (body) {
@@ -12,6 +20,6 @@ export async function api<T>(method: string, path: string, body?: unknown): Prom
   } catch {
     throw new Error(`Server error: ${r.status} ${r.statusText}`);
   }
-  if (!r.ok) throw new Error((data as { error?: string }).error || "Request failed");
+  if (!r.ok) throw new ApiError((data as { error?: string }).error || "Request failed", r.status, data);
   return data as T;
 }

--- a/src/client/components/appointment-detail.tsx
+++ b/src/client/components/appointment-detail.tsx
@@ -7,18 +7,31 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { StatusBadge } from "./status-badge";
+import { conflictsFrom, conflictSentence } from "@/lib/conflicts";
 
 export function AppointmentDetail() {
   const {
     selectedAppointment: apt, navigate, updateAppointment, deleteAppointment,
-    addAppointmentNote, deleteAppointmentNote, staffLookup,
+    addAppointmentNote, deleteAppointmentNote, staffLookup, setError,
   } = useApp();
   const [noteText, setNoteText] = useState("");
 
   if (!apt) return null;
 
-  const handleStatusChange = (status: string) => updateAppointment(apt.id, { status } as Partial<typeof apt>);
-  const handleStaffChange = (staffId: string) => updateAppointment(apt.id, { staff_id: staffId ? parseInt(staffId) : null } as Partial<typeof apt>);
+  // Reassigning can now be refused, because the new person may already be busy.
+  const save = async (patch: Partial<typeof apt>) => {
+    try {
+      await updateAppointment(apt.id, patch);
+    } catch (err) {
+      const clashes = conflictsFrom(err);
+      setError(clashes
+        ? conflictSentence(staffLookup.find((s) => s.id === patch.staff_id)?.name ?? "", clashes)
+        : (err as Error).message);
+    }
+  };
+
+  const handleStatusChange = (status: string) => save({ status } as Partial<typeof apt>);
+  const handleStaffChange = (staffId: string) => save({ staff_id: staffId ? parseInt(staffId) : null } as Partial<typeof apt>);
 
   const handleAddNote = async () => {
     if (!noteText.trim()) return;

--- a/src/client/components/calendar-view.tsx
+++ b/src/client/components/calendar-view.tsx
@@ -1,5 +1,6 @@
 import { useState } from "preact/hooks";
 import { useApp } from "../context";
+import type { Appointment, BlockedSlot } from "../types";
 import { ChevronLeft, ChevronRight, Plus, X, Ban } from "lucide-preact";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -7,12 +8,44 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { CreateAppointment } from "./create-appointment";
 import { cn } from "@/lib/utils";
+import { packLanes } from "@/lib/overlap";
 
 const HOURS = Array.from({ length: 14 }, (_, i) => i + 7); // 7 AM to 8 PM
 
 function timeToMinutes(time: string): number {
   const [h, m] = time.split(":").map(Number);
   return h * 60 + m;
+}
+
+/**
+ * Lay a column's appointments and blocked slots out side by side.
+ *
+ * Blocked time is packed together with the bookings because it competes for the
+ * same person: drawing a booking over the top of a lunch break hid the break.
+ */
+function layOutColumn(
+  appointments: Appointment[],
+  blocked: BlockedSlot[],
+  dayStart: number,
+) {
+  return packLanes([
+    ...blocked.map((b) => ({
+      key: `b-${b.id}`, block: b, appointment: null as Appointment | null,
+      start: timeToMinutes(b.start_time) - dayStart,
+      end: timeToMinutes(b.end_time) - dayStart,
+    })),
+    ...appointments.map((a) => ({
+      key: `a-${a.id}`, block: null as BlockedSlot | null, appointment: a,
+      start: timeToMinutes(a.start_time) - dayStart,
+      end: timeToMinutes(a.end_time) - dayStart,
+    })),
+  ]);
+}
+
+/** Where a laid-out span sits across the width of its column. */
+function laneStyle(lane: number, lanes: number) {
+  const width = 100 / lanes;
+  return { left: `calc(${lane * width}% + 4px)`, width: `calc(${width}% - 8px)` };
 }
 
 function formatHour(h: number): string {
@@ -146,49 +179,47 @@ export function CalendarView() {
                     />
                   ))}
 
-                  {/* Blocked slots */}
-                  {memberBlocked.map((block) => {
-                    const startMin = timeToMinutes(block.start_time) - dayStart;
-                    const endMin = timeToMinutes(block.end_time) - dayStart;
-                    const top = (startMin / totalMinutes) * totalHeight;
-                    const height = ((endMin - startMin) / totalMinutes) * totalHeight;
-                    return (
-                      <div
-                        key={`b-${block.id}`}
-                        className="absolute inset-x-1 z-10 flex items-center justify-between rounded bg-muted/60 px-2 text-xs text-muted-foreground"
-                        style={{ top, height: Math.max(height, 20) }}
-                      >
-                        <span className="truncate">{block.reason || "Blocked"}</span>
-                        <button
-                          className="flex-shrink-0 rounded p-0.5 hover:bg-muted"
-                          onClick={(e) => { e.stopPropagation(); deleteBlockedSlot(block.id); }}
-                        >
-                          <X className="h-3 w-3" />
-                        </button>
-                      </div>
-                    );
-                  })}
+                  {layOutColumn(memberAppts, memberBlocked, dayStart).map((item) => {
+                    const top = (item.start / totalMinutes) * totalHeight;
+                    const height = ((item.end - item.start) / totalMinutes) * totalHeight;
+                    const lane = laneStyle(item.lane, item.lanes);
 
-                  {/* Appointments */}
-                  {memberAppts.map((apt) => {
-                    const startMin = timeToMinutes(apt.start_time) - dayStart;
-                    const endMin = timeToMinutes(apt.end_time) - dayStart;
-                    const top = (startMin / totalMinutes) * totalHeight;
-                    const height = ((endMin - startMin) / totalMinutes) * totalHeight;
+                    if (item.block) {
+                      const block = item.block;
+                      return (
+                        <div
+                          key={item.key}
+                          className="absolute z-10 flex items-center justify-between rounded bg-muted/60 px-2 text-xs text-muted-foreground"
+                          style={{ ...lane, top, height: Math.max(height, 20) }}
+                        >
+                          <span className="truncate">{block.reason || "Blocked"}</span>
+                          <button
+                            className="flex-shrink-0 rounded p-0.5 hover:bg-muted"
+                            onClick={(e) => { e.stopPropagation(); deleteBlockedSlot(block.id); }}
+                          >
+                            <X className="h-3 w-3" />
+                          </button>
+                        </div>
+                      );
+                    }
+
+                    const apt = item.appointment!;
                     const services = apt.appointment_services?.map((s) => s.service_name).filter(Boolean).join(", ");
                     return (
                       <button
-                        key={apt.id}
+                        key={item.key}
                         className={cn(
-                          "absolute inset-x-1 z-20 cursor-pointer overflow-hidden rounded-md border-l-[3px] px-2 py-1 text-left transition-shadow hover:shadow-md",
+                          "absolute z-20 cursor-pointer overflow-hidden rounded-md border-l-[3px] px-2 py-1 text-left transition-shadow hover:shadow-md",
                         )}
                         style={{
+                          ...lane,
                           top,
                           height: Math.max(height, 28),
                           backgroundColor: `${member.color}14`,
                           borderLeftColor: member.color,
                         }}
                         onClick={() => navigate(`/appointments/${apt.id}`)}
+                        title={`${apt.start_time} - ${apt.end_time} ${apt.client_name ?? ""}`}
                       >
                         <div className="text-[10px] font-medium text-muted-foreground">{apt.start_time} - {apt.end_time}</div>
                         <div className="truncate text-xs font-semibold">{apt.client_name}</div>
@@ -216,16 +247,15 @@ export function CalendarView() {
                   {HOURS.map((h) => (
                     <div key={h} className="absolute left-0 right-0 border-t border-dashed border-border/50" style={{ top: ((h * 60 - dayStart) / totalMinutes) * totalHeight }} />
                   ))}
-                  {unassigned.map((apt) => {
-                    const startMin = timeToMinutes(apt.start_time) - dayStart;
-                    const endMin = timeToMinutes(apt.end_time) - dayStart;
-                    const top = (startMin / totalMinutes) * totalHeight;
-                    const height = ((endMin - startMin) / totalMinutes) * totalHeight;
+                  {layOutColumn(unassigned, [], dayStart).map((item) => {
+                    const apt = item.appointment!;
+                    const top = (item.start / totalMinutes) * totalHeight;
+                    const height = ((item.end - item.start) / totalMinutes) * totalHeight;
                     return (
                       <button
-                        key={apt.id}
-                        className="absolute inset-x-1 z-20 cursor-pointer overflow-hidden rounded-md border-l-[3px] border-l-muted-foreground/40 bg-muted/30 px-2 py-1 text-left transition-shadow hover:shadow-md"
-                        style={{ top, height: Math.max(height, 28) }}
+                        key={item.key}
+                        className="absolute z-20 cursor-pointer overflow-hidden rounded-md border-l-[3px] border-l-muted-foreground/40 bg-muted/30 px-2 py-1 text-left transition-shadow hover:shadow-md"
+                        style={{ ...laneStyle(item.lane, item.lanes), top, height: Math.max(height, 28) }}
                         onClick={() => navigate(`/appointments/${apt.id}`)}
                       >
                         <div className="text-[10px] font-medium text-muted-foreground">{apt.start_time} - {apt.end_time}</div>

--- a/src/client/components/create-appointment.tsx
+++ b/src/client/components/create-appointment.tsx
@@ -1,6 +1,7 @@
 import { useState } from "preact/hooks";
 import { useApp } from "../context";
-import { X } from "lucide-preact";
+import { X, TriangleAlert } from "lucide-preact";
+import { conflictsFrom, describeConflict, type Conflict } from "@/lib/conflicts";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -22,6 +23,7 @@ export function CreateAppointment({ onClose, defaultDate }: Props) {
   const [selectedServices, setSelectedServices] = useState<number[]>([]);
   const [notes, setNotes] = useState("");
   const [saving, setSaving] = useState(false);
+  const [conflicts, setConflicts] = useState<Conflict[] | null>(null);
 
   const toggleService = (id: number) => {
     setSelectedServices((prev) =>
@@ -37,9 +39,10 @@ export function CreateAppointment({ onClose, defaultDate }: Props) {
     .filter((s) => selectedServices.includes(s.id))
     .reduce((sum, s) => sum + s.duration, 0);
 
-  const handleSubmit = async () => {
+  const handleSubmit = async (allowConflict = false) => {
     if (!clientId) { setError("Please select a client"); return; }
     setSaving(true);
+    setConflicts(null);
     try {
       await addAppointment({
         client_id: parseInt(clientId),
@@ -48,10 +51,15 @@ export function CreateAppointment({ onClose, defaultDate }: Props) {
         start_time: startTime,
         notes,
         service_ids: selectedServices,
+        ...(allowConflict ? { allow_conflict: true } : {}),
       });
       onClose();
     } catch (err) {
-      setError((err as Error).message);
+      // A clash is answered in the form, next to the time that caused it, rather
+      // than thrown at the page as a failure: the booking is one field away.
+      const clashes = conflictsFrom(err);
+      if (clashes) setConflicts(clashes);
+      else setError((err as Error).message);
     } finally {
       setSaving(false);
     }
@@ -74,7 +82,7 @@ export function CreateAppointment({ onClose, defaultDate }: Props) {
             </div>
             <div className="space-y-1.5">
               <Label>Staff</Label>
-              <select className="flex h-9 w-full rounded-md border border-input bg-background px-3 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" value={staffId} onChange={(e) => setStaffId((e.target as HTMLSelectElement).value)}>
+              <select className="flex h-9 w-full rounded-md border border-input bg-background px-3 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" value={staffId} onChange={(e) => { setStaffId((e.target as HTMLSelectElement).value); setConflicts(null); }}>
                 <option value="">Unassigned</option>
                 {staffLookup.map((s) => <option key={s.id} value={s.id}>{s.name}</option>)}
               </select>
@@ -83,11 +91,11 @@ export function CreateAppointment({ onClose, defaultDate }: Props) {
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1.5">
               <Label>Date</Label>
-              <Input type="date" value={date} onChange={(e) => setDate((e.target as HTMLInputElement).value)} />
+              <Input type="date" value={date} onChange={(e) => { setDate((e.target as HTMLInputElement).value); setConflicts(null); }} />
             </div>
             <div className="space-y-1.5">
               <Label>Start Time</Label>
-              <Input type="time" value={startTime} onChange={(e) => setStartTime((e.target as HTMLInputElement).value)} />
+              <Input type="time" value={startTime} onChange={(e) => { setStartTime((e.target as HTMLInputElement).value); setConflicts(null); }} />
             </div>
           </div>
 
@@ -123,9 +131,30 @@ export function CreateAppointment({ onClose, defaultDate }: Props) {
             <Textarea rows={3} placeholder="Special requests, preferences..." value={notes} onChange={(e) => setNotes((e.target as HTMLTextAreaElement).value)} />
           </div>
         </div>
+        {conflicts && (
+          <div className="flex gap-2.5 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
+            <TriangleAlert className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-600" aria-hidden="true" />
+            <div className="space-y-1">
+              <p className="font-medium">
+                {staffLookup.find((s) => String(s.id) === staffId)?.name ?? "That staff member"} is not free then.
+              </p>
+              <ul className="text-muted-foreground">
+                {conflicts.map((c) => (
+                  <li key={`${c.start_time}-${c.label}`}>{describeConflict(c)}</li>
+                ))}
+              </ul>
+              <p className="text-muted-foreground">Pick another time or staff member, or book it anyway.</p>
+            </div>
+          </div>
+        )}
         <DialogFooter>
           <Button variant="outline" onClick={onClose}>Cancel</Button>
-          <Button disabled={saving} onClick={handleSubmit}>
+          {conflicts && (
+            <Button variant="outline" disabled={saving} onClick={() => handleSubmit(true)}>
+              Book anyway
+            </Button>
+          )}
+          <Button disabled={saving} onClick={() => handleSubmit()}>
             {saving ? "Booking..." : "Create Booking"}
           </Button>
         </DialogFooter>

--- a/src/client/context.tsx
+++ b/src/client/context.tsx
@@ -27,6 +27,7 @@ export interface AppContextValue {
     is_recurring?: number;
     recurrence_interval?: string;
     service_ids?: number[];
+    allow_conflict?: boolean;
   }) => Promise<void>;
   updateAppointment: (id: number, data: Partial<Appointment>) => Promise<void>;
   deleteAppointment: (id: number) => Promise<void>;

--- a/src/client/hooks/use-app.ts
+++ b/src/client/hooks/use-app.ts
@@ -148,6 +148,7 @@ export function useAppState(isAgent: boolean, navigate: (to: string) => void): A
   const addAppointment = useCallback(async (data: {
     client_id: number; staff_id?: number | null; scheduled_date: string;
     start_time?: string; notes?: string; is_recurring?: number; recurrence_interval?: string; service_ids?: number[];
+    allow_conflict?: boolean;
   }) => {
     await api("POST", "/api/appointments", data);
     await fetchAppointments(appointmentsPag, appointmentsSearch, appointmentsStatusFilter);

--- a/src/client/lib/conflicts.ts
+++ b/src/client/lib/conflicts.ts
@@ -1,0 +1,30 @@
+import { ApiError } from "../api";
+
+/** One thing already in the way of a booking, as the API reports it. */
+export type Conflict = {
+  kind: "appointment" | "blocked";
+  start_time: string;
+  end_time: string;
+  /** The client holding the slot, or the reason the time is blocked. */
+  label: string;
+};
+
+/**
+ * The clashes behind a rejected booking, or `null` if it failed for some other
+ * reason. Lets a caller answer a clash in place and leave everything else to the
+ * usual error path.
+ */
+export function conflictsFrom(err: unknown): Conflict[] | null {
+  if (!(err instanceof ApiError) || err.status !== 409) return null;
+  return (err.body as { conflicts?: Conflict[] }).conflicts ?? [];
+}
+
+/** `"10:00 - 11:00 booked for Jamie Rivera"`, or the reason for a blocked slot. */
+export function describeConflict(c: Conflict): string {
+  return `${c.start_time} - ${c.end_time} ${c.kind === "blocked" ? c.label : `booked for ${c.label}`}`;
+}
+
+/** One sentence, for the places with no room to list the clashes. */
+export function conflictSentence(who: string, conflicts: Conflict[]): string {
+  return `${who || "That staff member"} is not free then: ${conflicts.map(describeConflict).join(", ")}.`;
+}

--- a/src/client/lib/overlap.test.ts
+++ b/src/client/lib/overlap.test.ts
@@ -1,0 +1,74 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { packLanes } from "./overlap.ts";
+
+/** `packLanes` output as `"start-end:lane/lanes"`, sorted, for readable asserts. */
+const shape = (spans: { start: number; end: number }[]) =>
+  packLanes(spans).map((p) => `${p.start}-${p.end}:${p.lane}/${p.lanes}`);
+
+test("a day with no overlaps keeps every appointment full width", () => {
+  assert.deepEqual(shape([{ start: 600, end: 660 }, { start: 720, end: 780 }]),
+    ["600-660:0/1", "720-780:0/1"]);
+});
+
+test("back-to-back appointments do not split the column", () => {
+  assert.deepEqual(shape([{ start: 600, end: 660 }, { start: 660, end: 720 }]),
+    ["600-660:0/1", "660-720:0/1"]);
+});
+
+test("two overlapping appointments each take half the column", () => {
+  assert.deepEqual(shape([{ start: 600, end: 660 }, { start: 630, end: 690 }]),
+    ["600-660:0/2", "630-690:1/2"]);
+});
+
+test("a third overlapping appointment takes a third each", () => {
+  assert.deepEqual(shape([
+    { start: 600, end: 690 },
+    { start: 610, end: 700 },
+    { start: 620, end: 710 },
+  ]), ["600-690:0/3", "610-700:1/3", "620-710:2/3"]);
+});
+
+test("a lane is reused once its appointment has ended", () => {
+  // A long booking overlaps two short ones that follow each other, so the
+  // column splits in two rather than three.
+  assert.deepEqual(shape([
+    { start: 600, end: 780 },
+    { start: 610, end: 660 },
+    { start: 660, end: 720 },
+  ]), ["600-780:0/2", "610-660:1/2", "660-720:1/2"]);
+});
+
+test("overlaps chained through a middle booking share one cluster", () => {
+  // First and last do not touch each other but both touch the middle, so all
+  // three are laid out together. Two lanes is enough: the first and last never
+  // share a minute, so they can stack in the same one and nothing is hidden.
+  assert.deepEqual(shape([
+    { start: 600, end: 640 },
+    { start: 630, end: 700 },
+    { start: 660, end: 720 },
+  ]), ["600-640:0/2", "630-700:1/2", "660-720:0/2"]);
+});
+
+test("a busy morning does not widen a quiet afternoon", () => {
+  assert.deepEqual(shape([
+    { start: 600, end: 660 },
+    { start: 630, end: 690 },
+    { start: 840, end: 900 },
+  ]), ["600-660:0/2", "630-690:1/2", "840-900:0/1"]);
+});
+
+test("input order does not change the layout", () => {
+  const spans = [{ start: 630, end: 690 }, { start: 600, end: 660 }];
+  assert.deepEqual(shape(spans), ["600-660:0/2", "630-690:1/2"]);
+});
+
+test("the caller's own fields survive, and its array is left alone", () => {
+  const spans = [{ start: 630, end: 690, id: "b" }, { start: 600, end: 660, id: "a" }];
+  assert.deepEqual(packLanes(spans).map((p) => p.id), ["a", "b"]);
+  assert.deepEqual(spans.map((s) => s.id), ["b", "a"]);
+});
+
+test("an empty column is not a crash", () => {
+  assert.deepEqual(packLanes([]), []);
+});

--- a/src/client/lib/overlap.ts
+++ b/src/client/lib/overlap.ts
@@ -1,0 +1,54 @@
+/**
+ * Side-by-side layout for a calendar column.
+ *
+ * A staff column draws every appointment at full width, so two bookings on the
+ * same person at the same time land exactly on top of each other and the one
+ * underneath disappears. Overlaps are rarer now the API rejects them, but they
+ * still happen on purpose (a colour processes while the next client is cut) and
+ * every database written by an older build is full of accidental ones. A double
+ * booking you cannot see is worse than one you can.
+ *
+ * Spans are laid out the way every day-view calendar does it: anything that
+ * overlaps shares the column, split evenly.
+ */
+
+export type Span = { start: number; end: number };
+
+/** Which slice of the column a span gets: lane `i` of `lanes`. */
+export type Placed<T> = T & { lane: number; lanes: number };
+
+/**
+ * Assign each span a lane so overlapping spans sit next to each other.
+ *
+ * Spans that overlap, directly or through a chain of others, form a cluster and
+ * share the column between them. A span alone in its cluster keeps the full
+ * width, so a normal day looks exactly as it did before.
+ */
+export function packLanes<T extends Span>(spans: T[]): Placed<T>[] {
+  const sorted = [...spans].sort((a, b) => a.start - b.start || a.end - b.end);
+  const placed: Placed<T>[] = [];
+
+  let cluster: Placed<T>[] = [];
+  // The end of each open lane in the current cluster.
+  let laneEnds: number[] = [];
+
+  const closeCluster = () => {
+    for (const p of cluster) p.lanes = laneEnds.length;
+    placed.push(...cluster);
+    cluster = [];
+    laneEnds = [];
+  };
+
+  for (const span of sorted) {
+    // A span starting after everything so far has ended begins a new cluster.
+    if (cluster.length > 0 && span.start >= Math.max(...laneEnds)) closeCluster();
+
+    let lane = laneEnds.findIndex((end) => end <= span.start);
+    if (lane === -1) lane = laneEnds.length;
+    laneEnds[lane] = span.end;
+    cluster.push({ ...span, lane, lanes: 1 });
+  }
+  closeCluster();
+
+  return placed;
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,5 +1,6 @@
 import { createApp, createRoute, z } from "@clawnify/app";
 import { query, get, run } from "./db.js";
+import { findConflicts, describeConflicts, toMinutes, type Busy } from "./scheduling.js";
 
 type Env = { Bindings: { DB: D1Database } };
 
@@ -13,6 +14,16 @@ const app = createApp<Env>({
 
 const ErrorSchema = z.object({ error: z.string() }).openapi("Error");
 const OkSchema = z.object({ ok: z.boolean() }).openapi("Ok");
+
+const ConflictSchema = z.object({
+  error: z.string(),
+  conflicts: z.array(z.object({
+    kind: z.enum(["appointment", "blocked"]),
+    start_time: z.string(),
+    end_time: z.string(),
+    label: z.string(),
+  })),
+}).openapi("Conflict");
 
 const ClientSchema = z.object({
   id: z.number().int(),
@@ -131,6 +142,45 @@ function addMinutes(time: string, minutes: number): string {
   const hh = Math.floor(total / 60) % 24;
   const mm = total % 60;
   return `${String(hh).padStart(2, "0")}:${String(mm).padStart(2, "0")}`;
+}
+
+/**
+ * What already occupies `staffId` on `date`: their other appointments, plus any
+ * time blocked off for lunch, holiday and the like.
+ *
+ * Cancelled appointments free the chair, and are the one status left out. That
+ * matches what `/api/calendar` draws, so the rule an owner sees is simply
+ * "if it is on the calendar, it is taken".
+ */
+async function busyFor(staffId: number, date: string, excludeAppointmentId?: number): Promise<Busy[]> {
+  const appts = await query<{ start_time: string; end_time: string; client_name: string | null }>(
+    `SELECT a.start_time, a.end_time, cl.name as client_name
+     FROM appointments a
+     LEFT JOIN clients cl ON cl.id = a.client_id
+     WHERE a.staff_id = ? AND a.scheduled_date = ? AND a.status != 'cancelled'
+       ${excludeAppointmentId ? "AND a.id != ?" : ""}`,
+    excludeAppointmentId ? [staffId, date, excludeAppointmentId] : [staffId, date],
+  );
+  const blocks = await query<{ start_time: string; end_time: string; reason: string | null }>(
+    "SELECT start_time, end_time, reason FROM blocked_slots WHERE staff_id = ? AND blocked_date = ?",
+    [staffId, date],
+  );
+  return [
+    ...appts.map((a): Busy => ({
+      kind: "appointment", start_time: a.start_time, end_time: a.end_time,
+      label: a.client_name || "another booking",
+    })),
+    ...blocks.map((b): Busy => ({
+      kind: "blocked", start_time: b.start_time, end_time: b.end_time,
+      label: b.reason || "blocked",
+    })),
+  ];
+}
+
+/** The staff member's name, for the conflict message. */
+async function staffName(staffId: number): Promise<string> {
+  const s = await get<{ name: string }>("SELECT name FROM staff WHERE id = ?", [staffId]);
+  return s?.name || "";
 }
 
 // ── Stats ──────────────────────────────────────────────────────────
@@ -355,10 +405,14 @@ const createAppointment = createRoute({
       is_recurring: z.number().int().optional(),
       recurrence_interval: z.string().optional(),
       service_ids: z.array(z.number().int()).optional(),
+      allow_conflict: z.boolean().optional().openapi({
+        description: "Book even though the staff member is already busy then. Salons do deliberately overlap (a colour processes while the next client is cut), so this is allowed, but never by accident.",
+      }),
     }) } } },
   },
   responses: {
     201: { description: "Created", content: { "application/json": { schema: z.object({ appointment: AppointmentSchema }) } } },
+    409: { description: "Staff member is already busy", content: { "application/json": { schema: ConflictSchema } } },
   },
 });
 
@@ -382,6 +436,14 @@ app.openapi(createAppointment, async (c) => {
   }
 
   const endTime = addMinutes(startTime, totalDuration);
+
+  // Nothing to contend for when the booking is unassigned.
+  if (body.staff_id && !body.allow_conflict) {
+    const conflicts = findConflicts(startTime, endTime, await busyFor(body.staff_id, body.scheduled_date));
+    if (conflicts.length > 0) {
+      return c.json({ error: describeConflicts(await staffName(body.staff_id), conflicts), conflicts }, 409);
+    }
+  }
 
   const result = await run(
     `INSERT INTO appointments (identifier, client_id, staff_id, scheduled_date, start_time, end_time, total_price, notes, is_recurring, recurrence_interval)
@@ -432,26 +494,62 @@ const updateAppointment = createRoute({
       end_time: z.string().optional(),
       total_price: z.number().optional(),
       notes: z.string().optional(),
+      allow_conflict: z.boolean().optional().openapi({
+        description: "Move the appointment even though the staff member is already busy then.",
+      }),
     }) } } },
   },
   responses: {
     200: { description: "Updated", content: { "application/json": { schema: OkSchema } } },
+    400: { description: "Invalid times", content: { "application/json": { schema: ErrorSchema } } },
+    404: { description: "Not found", content: { "application/json": { schema: ErrorSchema } } },
+    409: { description: "Staff member is already busy", content: { "application/json": { schema: ConflictSchema } } },
   },
 });
 
 app.openapi(updateAppointment, async (c) => {
   const { id } = c.req.valid("param");
-  const body = c.req.valid("json");
+  const { allow_conflict, ...body } = c.req.valid("json");
+
+  const existing = await get<{
+    staff_id: number | null; scheduled_date: string; start_time: string; end_time: string;
+  }>("SELECT staff_id, scheduled_date, start_time, end_time FROM appointments WHERE id = ?", [id]);
+  if (!existing) return c.json({ error: "Not found" }, 404);
+
+  // Where the appointment lands once this patch is applied.
+  const staffId = body.staff_id !== undefined ? body.staff_id : existing.staff_id;
+  const date = body.scheduled_date ?? existing.scheduled_date;
+  const startTime = body.start_time ?? existing.start_time;
+
+  // Moving an appointment keeps its length. Without this, patching start_time
+  // alone left the old end_time behind and silently resized the booking.
+  let endTime = body.end_time;
+  if (endTime === undefined) {
+    const was = toMinutes(existing.start_time);
+    const wasEnd = toMinutes(existing.end_time);
+    const duration = was !== null && wasEnd !== null ? Math.max(wasEnd - was, 0) : 0;
+    endTime = addMinutes(startTime, duration);
+  }
+
+  const start = toMinutes(startTime);
+  const end = toMinutes(endTime);
+  if (start === null || end === null) return c.json({ error: "Times must be HH:MM" }, 400);
+  if (end <= start) return c.json({ error: "The appointment must end after it starts" }, 400);
+
+  if (staffId && !allow_conflict) {
+    const conflicts = findConflicts(startTime, endTime, await busyFor(staffId, date, Number(id)));
+    if (conflicts.length > 0) {
+      return c.json({ error: describeConflicts(await staffName(staffId), conflicts), conflicts }, 409);
+    }
+  }
+
   const sets: string[] = [];
   const params: unknown[] = [];
-
-  for (const [key, val] of Object.entries(body)) {
+  for (const [key, val] of Object.entries({ ...body, start_time: startTime, end_time: endTime })) {
     if (val !== undefined) { sets.push(`${key} = ?`); params.push(val); }
   }
-  if (sets.length > 0) {
-    sets.push("updated_at = datetime('now')");
-    await run(`UPDATE appointments SET ${sets.join(", ")} WHERE id = ?`, [...params, id]);
-  }
+  sets.push("updated_at = datetime('now')");
+  await run(`UPDATE appointments SET ${sets.join(", ")} WHERE id = ?`, [...params, id]);
   return c.json({ ok: true }, 200);
 });
 

--- a/src/server/scheduling.test.ts
+++ b/src/server/scheduling.test.ts
@@ -1,0 +1,85 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { toMinutes, overlaps, findConflicts, describeConflicts, type Busy } from "./scheduling.ts";
+
+const appt = (start_time: string, end_time: string, label = "Jamie Rivera"): Busy =>
+  ({ kind: "appointment", start_time, end_time, label });
+const block = (start_time: string, end_time: string, label = "Lunch"): Busy =>
+  ({ kind: "blocked", start_time, end_time, label });
+
+test("toMinutes reads wall clock, and rejects nonsense", () => {
+  assert.equal(toMinutes("00:00"), 0);
+  assert.equal(toMinutes("09:30"), 570);
+  assert.equal(toMinutes("23:59"), 1439);
+  assert.equal(toMinutes("9:05"), 545);
+  assert.equal(toMinutes("24:00"), null);
+  assert.equal(toMinutes("10:75"), null);
+  assert.equal(toMinutes("half ten"), null);
+  assert.equal(toMinutes(""), null);
+});
+
+test("intervals are half-open, so back-to-back is not a clash", () => {
+  // The next client sits down the minute the last one gets up.
+  assert.equal(overlaps({ start: 600, end: 660 }, { start: 660, end: 720 }), false);
+  assert.equal(overlaps({ start: 660, end: 720 }, { start: 600, end: 660 }), false);
+  // One minute of genuine overlap is a clash.
+  assert.equal(overlaps({ start: 600, end: 661 }, { start: 660, end: 720 }), true);
+});
+
+test("overlap is found however the two bookings sit", () => {
+  const candidate = ["10:00", "11:00"] as const;
+  const clash = (b: Busy) => findConflicts(candidate[0], candidate[1], [b]).length === 1;
+
+  assert.ok(clash(appt("10:00", "11:00")), "identical");
+  assert.ok(clash(appt("10:30", "11:30")), "starts inside");
+  assert.ok(clash(appt("09:30", "10:30")), "ends inside");
+  assert.ok(clash(appt("09:00", "12:00")), "swallows it");
+  assert.ok(clash(appt("10:15", "10:45")), "sits inside");
+  assert.ok(!clash(appt("11:00", "12:00")), "straight after");
+  assert.ok(!clash(appt("09:00", "10:00")), "straight before");
+  assert.ok(!clash(appt("14:00", "15:00")), "hours away");
+});
+
+test("blocked time is as binding as a booking", () => {
+  const found = findConflicts("13:30", "14:30", [block("13:00", "14:00")]);
+  assert.equal(found.length, 1);
+  assert.equal(found[0].kind, "blocked");
+});
+
+test("every clash is reported, not just the first", () => {
+  const found = findConflicts("10:00", "13:00", [
+    appt("09:00", "09:30"),   // before
+    appt("10:00", "11:00"),
+    block("11:30", "12:00"),
+    appt("14:00", "15:00"),   // after
+  ]);
+  assert.deepEqual(found.map((f) => f.start_time), ["10:00", "11:30"]);
+});
+
+test("a candidate that does not run forwards conflicts with nothing", () => {
+  // Rejecting it is the route's job; answering from a nonsense interval is not.
+  assert.deepEqual(findConflicts("14:00", "13:00", [appt("09:00", "20:00")]), []);
+  assert.deepEqual(findConflicts("14:00", "14:00", [appt("09:00", "20:00")]), []);
+  assert.deepEqual(findConflicts("nope", "11:00", [appt("09:00", "20:00")]), []);
+});
+
+test("a stored row that does not run forwards is skipped, not thrown on", () => {
+  // Older builds could write these: patching start_time left end_time behind.
+  assert.deepEqual(findConflicts("10:00", "11:00", [appt("10:00", "10:00")]), []);
+});
+
+test("the message tells the caller what is in the way and how to proceed", () => {
+  const msg = describeConflicts("Alex", [appt("10:00", "11:00", "Jamie Rivera")]);
+  assert.match(msg, /Alex is already booked at 10:00-11:00 \(Jamie Rivera\)/);
+  assert.match(msg, /allow_conflict/);
+});
+
+test("time blocked off reads as unavailable rather than booked", () => {
+  assert.match(describeConflicts("Alex", [block("13:00", "14:00", "Lunch")]), /unavailable at 13:00-14:00 \(Lunch\)/);
+  // Mixed causes fall back to the stronger word.
+  assert.match(describeConflicts("Alex", [block("13:00", "14:00"), appt("14:00", "15:00")]), /already booked/);
+});
+
+test("the message survives a staff member with no name on file", () => {
+  assert.match(describeConflicts("", [appt("10:00", "11:00")]), /^That staff member is already booked/);
+});

--- a/src/server/scheduling.ts
+++ b/src/server/scheduling.ts
@@ -1,0 +1,73 @@
+/**
+ * Booking conflict detection.
+ *
+ * Pure interval maths, no database, so the rules can be unit-tested directly.
+ *
+ * Intervals are half-open `[start, end)`. That is the whole reason a 10:00-11:00
+ * cut and an 11:00-12:00 colour are back-to-back rather than a clash: in a salon
+ * the next client sits down the minute the last one gets up.
+ *
+ * Times are `HH:MM` wall clock in the business's own day. Minutes are counted
+ * from midnight.
+ */
+
+export type Interval = { start: number; end: number };
+
+/** Something already occupying a staff member's day. */
+export type Busy = {
+  kind: "appointment" | "blocked";
+  start_time: string;
+  end_time: string;
+  /** Who or what holds the slot: the client's name, or the reason for the block. */
+  label: string;
+};
+
+/** `"09:30"` -> `570`. Returns `null` for anything unparseable. */
+export function toMinutes(time: string): number | null {
+  const m = /^(\d{1,2}):(\d{2})/.exec(time ?? "");
+  if (!m) return null;
+  const h = Number(m[1]);
+  const min = Number(m[2]);
+  if (h > 23 || min > 59) return null;
+  return h * 60 + min;
+}
+
+/** Do two half-open intervals share any minute? */
+export function overlaps(a: Interval, b: Interval): boolean {
+  return a.start < b.end && b.start < a.end;
+}
+
+/**
+ * Everything in `busy` that collides with `[start_time, end_time)`.
+ *
+ * A candidate that does not parse, or that does not run forwards, is treated as
+ * having no conflicts: it is the caller's job to reject it, and answering
+ * "clashes with nothing" is safer than answering from a nonsense interval.
+ */
+export function findConflicts(start_time: string, end_time: string, busy: Busy[]): Busy[] {
+  const start = toMinutes(start_time);
+  const end = toMinutes(end_time);
+  if (start === null || end === null || end <= start) return [];
+  return busy.filter((b) => {
+    const bs = toMinutes(b.start_time);
+    const be = toMinutes(b.end_time);
+    if (bs === null || be === null || be <= bs) return false;
+    return overlaps({ start, end }, { start: bs, end: be });
+  });
+}
+
+/**
+ * The 409 message.
+ *
+ * Written to be acted on rather than just read: an agent booking on behalf of
+ * the owner gets the times that are taken and the two ways out, so it can offer
+ * another slot instead of failing the request back to a human.
+ */
+export function describeConflicts(staffName: string, conflicts: Busy[]): string {
+  const who = staffName || "That staff member";
+  const list = conflicts
+    .map((c) => `${c.start_time}-${c.end_time} (${c.label})`)
+    .join(", ");
+  const what = conflicts.every((c) => c.kind === "blocked") ? "unavailable" : "already booked";
+  return `${who} is ${what} at ${list}. Choose another time or staff member, or send allow_conflict: true to book over it anyway.`;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
Appointments could silently overlap another booking or blocked time, and moving only `start_time` left the old end time behind. This adds explicit conflict responses, an intentional “Book anyway” path, and side-by-side calendar cards for overlaps.

- Creating, moving, reassigning, and restoring a cancelled booking check the staff member's occupied time. Adjacent bookings are allowed; unassigned and cancelled bookings do not reserve a staff member.
- Existing overlaps can still be cancelled, checked in, completed, or have their notes edited. Routine updates do not require another override.
- Moves preserve duration. Invalid times, zero-duration bookings, and bookings that wrap past midnight are rejected; the current date model supports appointments within one day.
- The API returns structured 409 conflicts and documents `allow_conflict` in OpenAPI. The booking dialog lists the conflicts and clears stale warnings when services, staff, date, or time change. Its contents scroll on short screens.
- Calendar appointments and blocked slots share horizontal lanes so overlaps remain visible.

Validation: 32 passing tests, including seven tests through the actual Hono routes and SQLite; five route tests fail against the original PR implementation. Production build passes. TypeScript has the same 59 existing file/error-code categories as main. TaskWindow checks covered next/previous/Today in Europe/Amsterdam, conflict refusal, “Book anyway”, separate calendar cards, and the booking dialog at 390px and 1280px.

The conflict check is an application-level read before write, not a database reservation; simultaneous requests across processes remain a concurrency limitation. Overnight appointments, salon timezone settings, and staff working hours are outside this change.
